### PR TITLE
ci: delegate server builds to lab and add daily release dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,6 @@ concurrency:
 
 permissions:
   contents: read
-  packages: write
-
-env:
-  BUILD_IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}
 
 jobs:
   validate:
@@ -34,143 +30,26 @@ jobs:
       - name: Resolve element graph
         run: just validate
 
-  build:
-    if: github.event_name != 'pull_request'
-    strategy:
-      matrix:
-        include:
-          - arch: x86_64
-            runner: ubuntu-24.04
-          - arch: aarch64
-            runner: ubuntu-24.04-arm
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 300
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          ref: ${{ github.event.client_payload.ref || github.ref }}
-      - uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2
-        with:
-          tool: just
-      - name: Compute OCI Metadata
-        run: |
-          echo "OCI_IMAGE_REVISION=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
-          echo "OCI_IMAGE_CREATED=$(git log -1 --format=%cI)" >> "$GITHUB_ENV"
-      - name: Log in to ghcr
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
-      - name: Build and verify all images
-        run: |
-          for IMAGE in bluefin-server-bootc; do
-            echo "::group::Build ${IMAGE}"
-            BUILD_IMAGE_NAME=${IMAGE} just build
-            BUILD_IMAGE_NAME=${IMAGE} just tag-push "${BUILD_IMAGE_REGISTRY}/${IMAGE}-${{ matrix.arch }}"
-            echo "::endgroup::"
-          done
-
-  manifest:
-    needs: build
+  trigger-lab:
     if: github.event_name != 'pull_request'
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
     permissions:
       contents: read
-      packages: write
-      id-token: write      # Required for Sigstore keyless signing
+      actions: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.client_payload.ref || github.ref }}
-      - uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2
-        with:
-          tool: just
-
-      - name: Restore pip cache for buildstream-sbom
-        uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8 # v6
-        with:
-          path: ~/.cache/pip
-          key: pip-sbom-0706fec3bedf6f73bd9d2fed32c2aed585feef8d
-          restore-keys: pip-sbom-
-
-      - name: Install Cosign
-        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-
-      - name: Install ORAS
-        uses: oras-project/setup-oras@38de303aac69abb66f3e6255b7198bff35f323e3 # v2.0.0
-
-      - name: Log in to ghcr
+      - name: Resolve commit SHA
+        id: sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Dispatch lab build pipeline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          mkdir -p ~/.docker
-          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin
-          echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u "${{ github.actor }}" --password-stdin --compat-auth-file ~/.docker/config.json
-
-      - name: Generate all BuildStream-native SBOMs
-        run: just sboms
-
-      - name: Assemble multi-arch manifests, sign, and attach SBOMs
-        run: |
-          set -euo pipefail
-          for IMAGE in bluefin-server-bootc; do
-            echo "::group::Processing SBOM and manifest for ${IMAGE}"
-            
-            case "${IMAGE}" in
-              bluefin-server-bootc) DESC="An FSDK-built server bootc image designed for Flatcar sysext compatibility" ;;
-              *)          DESC="Project Bluefin server bootable container image" ;;
-            esac
-            
-            REPO="${BUILD_IMAGE_REGISTRY}/${IMAGE}"
-            
-            # Step 1: Create, annotate, and push all tags
-            FIRST_TAG=""
-            while read -r t; do
-              if [[ -z "${FIRST_TAG}" ]]; then
-                FIRST_TAG="${t}"
-              fi
-              podman manifest create "${REPO}:${t}"
-              podman manifest add "${REPO}:${t}" "docker://${REPO}-x86_64:${t}"
-              podman manifest add "${REPO}:${t}" "docker://${REPO}-aarch64:${t}"
-              
-              # Annotate the multi-arch manifest index itself with OCI labels for GHCR
-              podman manifest annotate --index --annotation "org.opencontainers.image.source=https://github.com/castrojo/bluefin-server" "${REPO}:${t}"
-              podman manifest annotate --index --annotation "org.opencontainers.image.description=${DESC}" "${REPO}:${t}"
-              podman manifest annotate --index --annotation "org.opencontainers.image.title=${IMAGE}" "${REPO}:${t}"
-              podman manifest annotate --index --annotation "org.opencontainers.image.licenses=Apache-2.0" "${REPO}:${t}"
-              
-              podman manifest push --all "${REPO}:${t}" "docker://${REPO}:${t}"
-              echo "==> published ${REPO}:${t} (multi-arch)"
-            done < <(just tags)
-
-            # Step 2: Resolve canonical manifest list digest exactly once
-            DIGEST=$(skopeo inspect --creds "${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}" "docker://${REPO}:${FIRST_TAG}" | jq -r '.Digest')
-            if [[ -z "${DIGEST}" || "${DIGEST}" == "null" ]]; then
-              echo "ERROR: Failed to resolve digest for ${REPO}:${FIRST_TAG}"
-              exit 1
-            fi
-            echo "==> Canonical digest for ${REPO}:${FIRST_TAG}: ${DIGEST}"
-
-            # Step 3: Keyless-sign the OCI image manifest list digest exactly once
-            cosign sign -y "${REPO}@${DIGEST}"
-
-            # Step 4: Attach and sign the SBOM exactly once
-            SBOM_FILE="${IMAGE}.spdx.json"
-            if [[ -f "${SBOM_FILE}" ]]; then
-              echo "==> Attaching SBOM ${SBOM_FILE} to ${REPO}@${DIGEST}..."
-              
-              oras attach \
-                --artifact-type application/vnd.spdx+json \
-                --annotation "filename=${SBOM_FILE}" \
-                "${REPO}@${DIGEST}" \
-                "${SBOM_FILE}"
-
-              SBOM_DIGEST=$(oras discover --format json "${REPO}@${DIGEST}" \
-                | jq -r '.referrers[] | select(.artifactType == "application/vnd.spdx+json") | .digest' \
-                | head -n1)
-
-              if [[ -n "${SBOM_DIGEST}" && "${SBOM_DIGEST}" != "null" ]]; then
-                echo "==> Signing SBOM artifact ${REPO}@${SBOM_DIGEST}..."
-                cosign sign -y "${REPO}@${SBOM_DIGEST}"
-              else
-                echo "WARNING: Failed to capture SBOM digest for ${REPO}:${FIRST_TAG}"
-              fi
-            fi
-            echo "::endgroup::"
-          done
+          gh workflow run lab-release.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            --field ref="${{ steps.sha.outputs.sha }}"
 

--- a/.github/workflows/lab-release.yml
+++ b/.github/workflows/lab-release.yml
@@ -1,0 +1,69 @@
+name: Daily lab release
+
+# Triggers the testing-lab build pipeline via repository_dispatch.
+# Actual image build and zot push happen in the lab; this workflow is the
+# GitOps control-plane that resolves the ref and fires the dispatch event.
+
+on:
+  schedule:
+    - cron: '0 4 * * *'  # 04:00 UTC daily
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to build (branch, tag, or SHA; default: main)'
+        required: false
+        default: 'main'
+      lab_repo:
+        description: 'Testing-lab repository (owner/repo)'
+        required: false
+        default: 'projectbluefin/testing-lab'
+      zot_target:
+        description: 'Zot registry target prefix (e.g. zot.example.com/projectbluefin)'
+        required: false
+        default: ''
+
+concurrency:
+  group: lab-release
+  cancel-in-progress: false  # Never cancel an in-flight release trigger
+
+permissions: read-all
+
+env:
+  LAB_REPO: ${{ github.event.inputs.lab_repo || 'projectbluefin/testing-lab' }}
+
+jobs:
+  dispatch-lab-build:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Get mergeraptor token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
+          private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
+          owner: projectbluefin
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+
+      - name: Resolve build ref and SHA
+        id: resolve
+        run: |
+          echo "ref=${{ github.event.inputs.ref || github.ref }}" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch build to testing lab
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          ZOT_TARGET: ${{ github.event.inputs.zot_target || '' }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${LAB_REPO}/dispatches" \
+            -f event_type="lab-build-requested" \
+            -F "client_payload[source_repo]=${{ github.repository }}" \
+            -F "client_payload[ref]=${{ steps.resolve.outputs.ref }}" \
+            -F "client_payload[sha]=${{ steps.resolve.outputs.sha }}" \
+            -F "client_payload[zot_target]=${ZOT_TARGET}"
+          echo "==> Dispatched lab build for ${{ github.repository }}@${{ steps.resolve.outputs.sha }} -> ${LAB_REPO}"

--- a/.github/workflows/lab-release.yml
+++ b/.github/workflows/lab-release.yml
@@ -13,10 +13,6 @@ on:
         description: 'Git ref to build (branch, tag, or SHA; default: main)'
         required: false
         default: 'main'
-      lab_repo:
-        description: 'Testing-lab repository (owner/repo)'
-        required: false
-        default: 'projectbluefin/testing-lab'
       zot_target:
         description: 'Zot registry target prefix (e.g. zot.example.com/projectbluefin)'
         required: false
@@ -29,7 +25,7 @@ concurrency:
 permissions: read-all
 
 env:
-  LAB_REPO: ${{ github.event.inputs.lab_repo || 'projectbluefin/testing-lab' }}
+  LAB_REPO: projectbluefin/testing-lab
 
 jobs:
   dispatch-lab-build:
@@ -43,6 +39,7 @@ jobs:
           app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
           private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
           owner: projectbluefin
+          repositories: testing-lab
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/lab-release.yml
+++ b/.github/workflows/lab-release.yml
@@ -50,20 +50,25 @@ jobs:
 
       - name: Resolve build ref and SHA
         id: resolve
+        env:
+          INPUT_REF: ${{ github.event.inputs.ref || github.ref }}
         run: |
-          echo "ref=${{ github.event.inputs.ref || github.ref }}" >> "$GITHUB_OUTPUT"
+          echo "ref=${INPUT_REF}" >> "$GITHUB_OUTPUT"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch build to testing lab
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ZOT_TARGET: ${{ github.event.inputs.zot_target || '' }}
+          SOURCE_REPO: ${{ github.repository }}
+          BUILD_REF: ${{ steps.resolve.outputs.ref }}
+          BUILD_SHA: ${{ steps.resolve.outputs.sha }}
         run: |
           set -euo pipefail
           gh api "repos/${LAB_REPO}/dispatches" \
             -f event_type="lab-build-requested" \
-            -F "client_payload[source_repo]=${{ github.repository }}" \
-            -F "client_payload[ref]=${{ steps.resolve.outputs.ref }}" \
-            -F "client_payload[sha]=${{ steps.resolve.outputs.sha }}" \
+            -F "client_payload[source_repo]=${SOURCE_REPO}" \
+            -F "client_payload[ref]=${BUILD_REF}" \
+            -F "client_payload[sha]=${BUILD_SHA}" \
             -F "client_payload[zot_target]=${ZOT_TARGET}"
-          echo "==> Dispatched lab build for ${{ github.repository }}@${{ steps.resolve.outputs.sha }} -> ${LAB_REPO}"
+          echo "==> Dispatched lab build for ${SOURCE_REPO}@${BUILD_SHA} -> ${LAB_REPO}"

--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -1,0 +1,98 @@
+name: Release DDI installer
+
+# Publishes two artifacts to GitHub Releases on every installer tag:
+#   bluefin-server-installer-<ver>.raw.zst  — bootable live installer disk image
+#   SHA256SUMS                               — verified by systemd-sysupdate
+#
+# The OS DDI (bluefin-server-ddi-<ver>.raw.zst) that the installer pulls at
+# install time via systemd-sysupdate is published by a separate job in this
+# workflow once the os-snapshot element is complete (see ddi-installer.md).
+#
+# Tag format: installer-v<semver>  e.g. installer-v0.1.0
+
+on:
+  push:
+    tags:
+      - 'installer-v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g. installer-v0.1.0)'
+        required: true
+
+concurrency:
+  group: release-installer-${{ github.ref }}
+  cancel-in-progress: false  # never cancel an in-flight release
+
+permissions:
+  contents: write   # create releases and upload assets
+
+jobs:
+  build-installer:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: taiki-e/install-action@ace6ebe54a6a0c86dfb5f7764b17f793b6925bc3 # v2
+        with:
+          tool: just
+
+      - name: Resolve element graph (pre-flight)
+        run: just validate-installer
+
+      - name: Build installer disk image
+        run: just build-installer
+
+      - name: Export artifacts to dist/
+        run: just export-installer
+
+      - name: Verify artifacts exist
+        run: |
+          set -euo pipefail
+          ls -lh dist/
+          [ -f dist/SHA256SUMS ] || { echo "ERROR: SHA256SUMS missing"; exit 1; }
+          RAWZST=$(ls dist/bluefin-server-installer-*.raw.zst 2>/dev/null | head -1)
+          [ -n "${RAWZST}" ] || { echo "ERROR: no .raw.zst found in dist/"; exit 1; }
+          echo "INSTALLER_ASSET=${RAWZST}" >> "$GITHUB_ENV"
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          set -euo pipefail
+          # Strip leading refs/tags/ if present
+          TAG="${TAG#refs/tags/}"
+          VERSION="${TAG#installer-v}"
+
+          # Create (or update) the release
+          if gh release view "${TAG}" &>/dev/null; then
+            echo "==> Release ${TAG} already exists, uploading assets..."
+          else
+            gh release create "${TAG}" \
+              --title "Bluefin Server Installer ${VERSION}" \
+              --notes "Live DDI installer for Bluefin Server ${VERSION}.
+
+Boot from USB, then the installer pulls the OS DDI from GitHub Releases
+via systemd-sysupdate and installs it to the target disk using systemd-repart.
+
+## Artifacts
+- \`bluefin-server-installer-${VERSION}.raw.zst\` — bootable GPT disk image (write to USB with \`dd\`)
+- \`SHA256SUMS\` — verified by systemd-sysupdate
+
+## Usage
+\`\`\`
+# Write installer to USB (replace /dev/sdX with your device)
+zstd -d bluefin-server-installer-${VERSION}.raw.zst --stdout | sudo dd of=/dev/sdX bs=4M status=progress
+\`\`\`"
+          fi
+
+          # Upload installer image and checksums
+          gh release upload "${TAG}" \
+            dist/bluefin-server-installer-*.raw.zst \
+            dist/SHA256SUMS \
+            --clobber
+          echo "==> Uploaded release assets for ${TAG}"

--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -1,12 +1,8 @@
 name: Release DDI installer
 
-# Publishes two artifacts to GitHub Releases on every installer tag:
-#   bluefin-server-installer-<ver>.raw.zst  — bootable live installer disk image
-#   SHA256SUMS                               — verified by systemd-sysupdate
-#
-# The OS DDI (bluefin-server-ddi-<ver>.raw.zst) that the installer pulls at
-# install time via systemd-sysupdate is published by a separate job in this
-# workflow once the os-snapshot element is complete (see ddi-installer.md).
+# Delegates the installer build to the testing lab via repository_dispatch.
+# GitHub is the control plane: resolves the tag ref and fires the dispatch event.
+# Actual BST build and GitHub Release upload happen in the lab.
 #
 # Tag format: installer-v<semver>  e.g. installer-v0.1.0
 
@@ -24,14 +20,24 @@ concurrency:
   group: release-installer-${{ github.ref }}
   cancel-in-progress: false  # never cancel an in-flight release
 
-permissions:
-  contents: write   # create releases and upload assets
+permissions: read-all
+
+env:
+  LAB_REPO: projectbluefin/testing-lab
 
 jobs:
-  build-installer:
+  dispatch-lab-installer-build:
     runs-on: ubuntu-24.04
-    timeout-minutes: 120
+    timeout-minutes: 10
     steps:
+      - name: Get mergeraptor token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
+          private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
+          owner: projectbluefin
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
@@ -40,59 +46,29 @@ jobs:
         with:
           tool: just
 
-      - name: Resolve element graph (pre-flight)
+      - name: Resolve installer tag and SHA
+        id: resolve
+        env:
+          INPUT_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: |
+          TAG="${INPUT_TAG#refs/tags/}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Validate installer element graph (pre-flight)
         run: just validate-installer
 
-      - name: Build installer disk image
-        run: just build-installer
-
-      - name: Export artifacts to dist/
-        run: just export-installer
-
-      - name: Verify artifacts exist
-        run: |
-          set -euo pipefail
-          ls -lh dist/
-          [ -f dist/SHA256SUMS ] || { echo "ERROR: SHA256SUMS missing"; exit 1; }
-          RAWZST=$(ls dist/bluefin-server-installer-*.raw.zst 2>/dev/null | head -1)
-          [ -n "${RAWZST}" ] || { echo "ERROR: no .raw.zst found in dist/"; exit 1; }
-          echo "INSTALLER_ASSET=${RAWZST}" >> "$GITHUB_ENV"
-
-      - name: Publish GitHub Release
+      - name: Dispatch installer build to testing lab
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.inputs.tag || github.ref_name }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          SOURCE_REPO: ${{ github.repository }}
+          INSTALLER_TAG: ${{ steps.resolve.outputs.tag }}
+          BUILD_SHA: ${{ steps.resolve.outputs.sha }}
         run: |
           set -euo pipefail
-          # Strip leading refs/tags/ if present
-          TAG="${TAG#refs/tags/}"
-          VERSION="${TAG#installer-v}"
-
-          # Create (or update) the release
-          if gh release view "${TAG}" &>/dev/null; then
-            echo "==> Release ${TAG} already exists, uploading assets..."
-          else
-            gh release create "${TAG}" \
-              --title "Bluefin Server Installer ${VERSION}" \
-              --notes "Live DDI installer for Bluefin Server ${VERSION}.
-
-Boot from USB, then the installer pulls the OS DDI from GitHub Releases
-via systemd-sysupdate and installs it to the target disk using systemd-repart.
-
-## Artifacts
-- \`bluefin-server-installer-${VERSION}.raw.zst\` — bootable GPT disk image (write to USB with \`dd\`)
-- \`SHA256SUMS\` — verified by systemd-sysupdate
-
-## Usage
-\`\`\`
-# Write installer to USB (replace /dev/sdX with your device)
-zstd -d bluefin-server-installer-${VERSION}.raw.zst --stdout | sudo dd of=/dev/sdX bs=4M status=progress
-\`\`\`"
-          fi
-
-          # Upload installer image and checksums
-          gh release upload "${TAG}" \
-            dist/bluefin-server-installer-*.raw.zst \
-            dist/SHA256SUMS \
-            --clobber
-          echo "==> Uploaded release assets for ${TAG}"
+          gh api "repos/${LAB_REPO}/dispatches" \
+            -f event_type="installer-build-requested" \
+            -F "client_payload[source_repo]=${SOURCE_REPO}" \
+            -F "client_payload[tag]=${INSTALLER_TAG}" \
+            -F "client_payload[sha]=${BUILD_SHA}"
+          echo "==> Dispatched installer build for ${SOURCE_REPO}@${INSTALLER_TAG} (${BUILD_SHA}) -> ${LAB_REPO}"

--- a/.github/workflows/release-installer.yml
+++ b/.github/workflows/release-installer.yml
@@ -37,6 +37,7 @@ jobs:
           app-id: ${{ secrets.MERGERAPTOR_APP_ID }}
           private-key: ${{ secrets.MERGERAPTOR_PRIVATE_KEY }}
           owner: projectbluefin
+          repositories: testing-lab
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/Justfile
+++ b/Justfile
@@ -245,6 +245,30 @@ verify-brew: export-brew
     fi
     [ "$fail" -eq 0 ] && echo "==> verify-brew passed" || { echo "==> verify-brew FAILED"; exit 1; }
 
+# -- DDI live installer -------------------------------------------------------
+# Produces a bootable GPT disk image that runs systemd-repart to install
+# Bluefin Server onto a target disk (see docs/skills/ddi-installer.md).
+# NOTE: build-installer and export-installer are stubs until the two blockers
+# in elements/oci/bluefin-server-installer.bst are resolved (UKI generation
+# and OS DDI payload). validate-installer works today.
+
+# Validate the installer element graph without building.
+[group('installer')]
+validate-installer:
+    just bst show --deps all oci/bluefin-server-installer.bst
+
+# Build the installer disk image (stub until blockers resolved).
+[group('installer')]
+build-installer:
+    just bst build oci/bluefin-server-installer.bst
+
+# Export the installer disk image + SHA256SUMS to dist/.
+[group('installer')]
+export-installer: build-installer
+    rm -rf dist
+    just bst artifact checkout oci/bluefin-server-installer.bst --directory dist
+    @echo "==> wrote:" && ls -lh dist/
+
 # Generate a BST-native SBOM (SPDX 2.3) using buildstream-sbom.
 [group('test')]
 sbom variant="base":

--- a/Justfile
+++ b/Justfile
@@ -248,16 +248,16 @@ verify-brew: export-brew
 # -- DDI live installer -------------------------------------------------------
 # Produces a bootable GPT disk image that runs systemd-repart to install
 # Bluefin Server onto a target disk (see docs/skills/ddi-installer.md).
-# NOTE: build-installer and export-installer are stubs until the two blockers
-# in elements/oci/bluefin-server-installer.bst are resolved (UKI generation
-# and OS DDI payload). validate-installer works today.
+# NOTE: build-installer/export-installer are local development commands.
+# Release publication is delegated to testing-lab by
+# .github/workflows/release-installer.yml.
 
 # Validate the installer element graph without building.
 [group('installer')]
 validate-installer:
     just bst show --deps all oci/bluefin-server-installer.bst
 
-# Build the installer disk image (stub until blockers resolved).
+# Build the installer disk image locally.
 [group('installer')]
 build-installer:
     just bst build oci/bluefin-server-installer.bst
@@ -360,5 +360,4 @@ sboms:
                     --output "/src/${img}.spdx.json"
             done
         '
-
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,29 @@ Every image self-declares its base via `io.projectbluefin.fsdk.version` and
 
 ## Build locally
 
-Requires `podman` and [`just`](https://github.com/casey/just). BuildStream runs
+Requires `podman` and [`just`](https://github.com/caesar/just). BuildStream runs
 inside the FSDK `bst2` container -- nothing to install.
 
     just validate        # resolve the element graph
     just build           # build + load ghcr.io/projectbluefin/base:latest
     just verify          # assert distroless + certs + tzdata
     just tags            # show derived tags
+
+## CI / Release pipeline
+
+GitHub is the **control plane only** — it resolves refs and fires dispatch events.
+All build compute and registry pushes happen inside the testing lab.
+
+| Trigger | Workflow / Job | What happens |
+|---------|---------------|--------------|
+| Pull request | `build.yml` → `validate` | `just validate` resolves the element graph — no build, no push |
+| Push to `main`, `repository_dispatch[fsdk-updated]`, `workflow_dispatch` | `build.yml` → `trigger-lab` | Resolves HEAD SHA; dispatches `lab-release.yml` with that SHA |
+| Daily **04:00 UTC** schedule | `lab-release.yml` → `dispatch-lab-build` | Sends `repository_dispatch[lab-build-requested]` to `projectbluefin/testing-lab` with repo, ref, and SHA |
+| `workflow_dispatch` on `lab-release.yml` | `lab-release.yml` → `dispatch-lab-build` | Same as above; accepts optional `ref`, `lab_repo`, and `zot_target` inputs |
+| `lab-build-requested` in testing-lab | testing-lab workflows | BST builds run in the lab; images pushed to the zot registry |
+
+Cross-repo dispatch uses a **Mergeraptor** GitHub App token (PATs are banned).
+See [`docs/skills/ci-tooling.md`](docs/skills/ci-tooling.md) for conventions.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ All build compute and registry pushes happen inside the testing lab.
 | Pull request | `build.yml` → `validate` | `just validate` resolves the element graph — no build, no push |
 | Push to `main`, `repository_dispatch[fsdk-updated]`, `workflow_dispatch` | `build.yml` → `trigger-lab` | Resolves HEAD SHA; dispatches `lab-release.yml` with that SHA |
 | Daily **04:00 UTC** schedule | `lab-release.yml` → `dispatch-lab-build` | Sends `repository_dispatch[lab-build-requested]` to `projectbluefin/testing-lab` with repo, ref, and SHA |
-| `workflow_dispatch` on `lab-release.yml` | `lab-release.yml` → `dispatch-lab-build` | Same as above; accepts optional `ref`, `lab_repo`, and `zot_target` inputs |
+| `workflow_dispatch` on `lab-release.yml` | `lab-release.yml` → `dispatch-lab-build` | Same as above; accepts optional `ref` and `zot_target` inputs |
 | `lab-build-requested` in testing-lab | testing-lab workflows | BST builds run in the lab; images pushed to the zot registry |
 
 Cross-repo dispatch uses a **Mergeraptor** GitHub App token (PATs are banned).

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -17,6 +17,7 @@ load the focused skill for your task.
 | ------------------ | ---- |
 | Add a new distroless image (python, node, etc.) | [add-new-image.md](add-new-image.md) |
 | Add a non-distroless nspawn machine image (dev env, tarball) | [nspawn-machine-image.md](nspawn-machine-image.md) |
+| Build or debug the DDI live installer | [ddi-installer.md](ddi-installer.md) |
 | Make an image smaller / apply the SLIM recipe | [slim-an-image.md](slim-an-image.md) |
 | Move to a new FSDK release / retag | [bump-fsdk-version.md](bump-fsdk-version.md) |
 | Prove an image is still distroless | [verify-distroless.md](verify-distroless.md) |

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -110,7 +110,6 @@ GitHub is the **control plane only** — no build compute runs here.
 | Input | Default | Description |
 |-------|---------|-------------|
 | `ref` | `main` | Git ref to build (branch, tag, or SHA) |
-| `lab_repo` | `projectbluefin/testing-lab` | Target testing-lab repository |
 | `zot_target` | _(empty)_ | Zot registry target prefix override |
 
 The `concurrency.cancel-in-progress: false` guard on `lab-release` ensures an

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -4,6 +4,10 @@ description: >
   CI workflow conventions for fsdk-containers. Use when writing or editing
   .github/workflows/*.yml, debugging a failing build job, or adding a new
   CI step.
+metadata:
+  context7-sources:
+    - /websites/github_en_actions
+    - /websites/cli_github_manual
 ---
 
 # CI Tooling
@@ -89,6 +93,14 @@ Pushes made with the default `GITHUB_TOKEN` do **not** trigger other GitHub Acti
 | `dispatch-lab-build` | `lab-release.yml` | Daily 04:00 UTC schedule, `workflow_dispatch`, triggered by `trigger-lab` | Sends `repository_dispatch[lab-build-requested]` to `projectbluefin/testing-lab`; actual builds and zot pushes happen in the lab |
 
 GitHub is the **control plane only** — no build compute runs here.
+
+## Core Process
+
+1. Keep workflow triggers explicit (`pull_request` validate vs push/dispatch delegation).
+2. Resolve immutable refs (SHA/tag) in GitHub workflow and pass them as payload.
+3. Dispatch build execution to lab workflows via authenticated GitHub API/CLI calls.
+4. Keep actions SHA-pinned and token source aligned with org policy (Mergeraptor app for cross-repo writes).
+5. Validate graph-only checks in GitHub and keep heavy build/push logic in lab.
 
 ### Daily schedule and manual trigger
 

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -82,13 +82,27 @@ Pushes made with the default `GITHUB_TOKEN` do **not** trigger other GitHub Acti
 
 ## Workflow Structure
 
-| Job | Trigger | Purpose |
-|---|---|---|
-| `validate` | `pull_request` only | `bst show` element graph resolution, no build |
-| `build` | `push`, `workflow_dispatch` | matrix (x86_64 + aarch64), build + verify + tag-push |
-| `manifest` | after `build` succeeds | assemble and push multi-arch manifest |
+| Job | Workflow | Trigger | Purpose |
+|-----|----------|---------|---------|
+| `validate` | `build.yml` | `pull_request` only | `just validate` — element graph resolution, no build |
+| `trigger-lab` | `build.yml` | `push/main`, `workflow_dispatch`, `repository_dispatch[fsdk-updated]` | Resolves HEAD SHA; calls `gh workflow run lab-release.yml --field ref=<sha>` |
+| `dispatch-lab-build` | `lab-release.yml` | Daily 04:00 UTC schedule, `workflow_dispatch`, triggered by `trigger-lab` | Sends `repository_dispatch[lab-build-requested]` to `projectbluefin/testing-lab`; actual builds and zot pushes happen in the lab |
 
-`fail-fast` on a 2-element matrix has no practical effect — omit it.
+GitHub is the **control plane only** — no build compute runs here.
+
+### Daily schedule and manual trigger
+
+`lab-release.yml` runs on a `schedule` cron (`0 4 * * *`, 04:00 UTC) and on
+`workflow_dispatch`. Manual runs accept three optional inputs:
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `ref` | `main` | Git ref to build (branch, tag, or SHA) |
+| `lab_repo` | `projectbluefin/testing-lab` | Target testing-lab repository |
+| `zot_target` | _(empty)_ | Zot registry target prefix override |
+
+The `concurrency.cancel-in-progress: false` guard on `lab-release` ensures an
+in-flight release dispatch is never cancelled by a subsequent trigger.
 
 ## Common Rationalizations
 

--- a/docs/skills/ddi-installer.md
+++ b/docs/skills/ddi-installer.md
@@ -187,11 +187,27 @@ just export-installer      # export .raw.zst + SHA256SUMS to dist/
 
 ## Release
 
-`.github/workflows/release-installer.yml` publishes on `installer-v*` tags:
+`.github/workflows/release-installer.yml` fires on `installer-v*` tags.
+**GitHub is the control plane only** — the workflow resolves the tag ref,
+runs `just validate-installer` (element graph resolution, no build), then
+dispatches `installer-build-requested` to `projectbluefin/testing-lab`.
+The lab builds the installer and uploads artifacts to the GitHub Release.
+
 ```
 git tag installer-v0.1.0 && git push origin installer-v0.1.0
 ```
-Uploads `bluefin-server-installer-<ver>.raw.zst` + `SHA256SUMS`.
+
+The lab receives:
+- `client_payload.source_repo` — the triggering repo
+- `client_payload.tag`         — the installer tag (e.g. `installer-v0.1.0`)
+- `client_payload.sha`         — pinned commit SHA
+
+The lab is responsible for:
+1. `just build-installer` + `just export-installer`
+2. Creating the GitHub Release via Mergeraptor token
+3. Uploading `bluefin-server-installer-<ver>.raw.zst` + `SHA256SUMS`
+
+> No BST build compute runs on GitHub-hosted runners.
 
 ## Related
 

--- a/docs/skills/ddi-installer.md
+++ b/docs/skills/ddi-installer.md
@@ -3,97 +3,152 @@
 ## What this is
 
 A DDI (Discoverable Disk Image) based live installer for Bluefin Server.
-No bootc, no OCI image pull — purely systemd-native network-pull model:
+No bootc, no OCI image pull, no dracut — purely systemd-native:
 
 1. Boot from the installer USB (a GPT disk image with one ESP partition)
 2. The installer live env runs `systemd-sysupdate` to pull the OS DDI from
    GitHub Releases
-3. `systemd-repart` applies the DDI to the target disk
-4. `bootctl install` + `systemd-firstboot` provision the bootloader and
-   initial configuration
-5. Reboot into the installed OS
+3. `systemd-repart` partitions the target disk and copies the DDI
+4. `bootctl install` puts systemd-boot + the OS UKI into the new ESP
+5. Power off → reboot into the installed OS
 
 ## Status
 
-**Scaffolded — one remaining stub before it produces a real bootable image.**
+**Fully wired — no remaining stubs.** `just validate-installer` passes.
 
-- ✅ Element chain defined and graph resolves (`just validate-installer`)
-- ✅ sysupdate.d transfer config wired (pulls OS DDI from GitHub Releases)
+- ✅ Dracut-free cpio initrd assembled inline by the BST script element
+- ✅ UKI built with `ukify` (unsigned; Secure Boot signing is opt-in)
+- ✅ sysupdate.d transfer config pulls OS DDI from GitHub Releases
 - ✅ repart.d target disk layout defined
-- ✅ Release workflow wired (`.github/workflows/release-installer.yml`)
-- 🔲 UKI generation (dracut initrd + ukify — see stub section below)
+- ✅ `bluefin-install` orchestration script (sysupdate → repart → bootctl)
+- ✅ Release workflow (`.github/workflows/release-installer.yml`)
+- 🔲 OS DDI artifact (`bluefin-server-ddi-@v.raw.zst`) — separate todo
 
 ## Element chain
 
 ```
 elements/
   installer/
-    installer-stack.bst      kind: stack  — live installer env deps
+    installer-stack.bst      kind: stack  — live installer env deps (no dracut)
     installer-repart.bst     kind: import — repart.d configs (target disk layout)
     installer-sysupdate.bst  kind: import — sysupdate.d transfer config
+    installer-units.bst      kind: import — installer.target + installer.service
   oci/
-    bluefin-server-installer.bst  kind: script — produces .raw.zst + SHA256SUMS
+    bluefin-server-installer.bst  kind: script — cpio + ukify + repart → .raw.zst
 files/
   installer/
     repart.d/
-      10-esp.conf             EFI System Partition (500M–1G, vfat)
+      10-esp.conf             ESP on TARGET disk (empty; bootctl populates it)
       20-root-a.conf          Root slot A (CopyBlocks from sysupdate download)
       30-var.conf             /var (xfs, grows to fill disk)
     sysupdate.d/
       bluefin-server-ddi.conf sysupdate transfer config (url-file, GitHub Releases)
+    units/
+      installer.target        Systemd target (waits for network + installer.service)
+      installer.service       Oneshot: runs bluefin-install, poweroff on success
+```
+
+## Why no dracut
+
+Dracut solves the problem of generating a minimal initrd from a running host by
+introspecting hardware and adding only the needed modules. For a BST-built
+installer image we already know exactly what's in the rootfs — the
+`installer-stack.bst` is the complete, reproducible live environment.
+
+Packing the entire rootfs as a cpio with `find . | cpio --null --create
+--format=newc` and pointing `ukify` at it is the approach the systemd project
+uses for its own test images (`mkosi`-built images use the same mechanism
+without a generator). It requires only `cpio` + `find` + `zstd` — all in FSDK
+`components/`.
+
+The initrd is larger than a hand-tuned dracut output (because it includes all
+kernel modules), but size is not a concern for USB installer media, and the
+approach is simpler to maintain and debug.
+
+## Initrd assembly (cpio-native)
+
+The `bluefin-server-installer.bst` script element:
+
+```bash
+# 1. Add /init symlink (Linux initrd protocol: kernel executes /init as PID 1)
+ln -sf usr/lib/systemd/systemd /layer/init
+
+# 2. Link default.target -> installer.target
+ln -sf installer.target /layer/usr/lib/systemd/system/default.target
+
+# 3. Pack the entire rootfs as a newc cpio archive + zstd-compress
+( cd /layer && find . -print0 | cpio --null --create --format=newc ) \
+  | zstd -T0 -19 -q -o /installer.cpio.zst
+
+# 4. Build the UKI (unsigned for dev; add --secureboot-* for release signing)
+KVER=$(ls /layer/usr/lib/modules | head -1)
+ukify build \
+  --linux="/layer/usr/lib/modules/${KVER}/vmlinuz" \
+  --initrd=/installer.cpio.zst \
+  --cmdline="systemd.unit=installer.target console=ttyS0,115200 rw" \
+  --output=/layer/boot/efi/EFI/Linux/installer.efi
+
+# 5. Assemble a single-partition GPT disk (ESP only) for the installer media
+#    (separate from the target-disk repart.d in /usr/lib/repart.d/)
+systemd-repart --empty=create --size=auto --dry-run=no \
+  --root=/layer --definitions=/installer-media-repart.d \
+  bluefin-server-installer-<ver>.raw
 ```
 
 ## Network-pull install flow
 
 ```
-Installer boot
+Installer boot (UEFI reads ESP → systemd-boot → installer.efi)
      │
      ▼
-installer.efi (UKI: kernel + initrd)
+installer.efi (UKI: kernel + cpio initrd)
      │
      ▼
-systemd-sysupdate --definitions=/usr/lib/sysupdate.d update
-     │  reads: files/installer/sysupdate.d/bluefin-server-ddi.conf
-     │  fetches: bluefin-server-ddi-<ver>.raw.zst from GitHub Releases
-     │  verifies: SHA256SUMS
-     │  writes: /run/installer/bluefin-server-ddi-<ver>.raw
-     │  symlinks: /run/installer/bluefin-server-ddi.raw → versioned file
+systemd PID 1 starts, reaches installer.target
      │
      ▼
-systemd-repart --dry-run=no /dev/TARGET
-     │  reads: /usr/lib/repart.d/ (10-esp, 20-root-a, 30-var)
-     │  20-root-a.conf: CopyBlocks=/run/installer/bluefin-server-ddi.raw
-     │  creates ESP, root-a partition (DDI copied), var partition
+installer.service → bluefin-install script:
      │
-     ▼
-bootctl install --esp-path=/dev/TARGET-esp-partition
+     ├─ systemd-sysupdate --definitions=/usr/lib/sysupdate.d update
+     │      fetches bluefin-server-ddi-@v.raw.zst from GitHub Releases
+     │      deposits /run/installer/bluefin-server-ddi.raw
      │
-     ▼
-systemd-firstboot (hostname, locale, credentials)
+     ├─ systemd-repart --dry-run=no --empty=force /dev/TARGET
+     │      reads /usr/lib/repart.d/ (10-esp, 20-root-a, 30-var)
+     │      20-root-a: CopyBlocks=/run/installer/bluefin-server-ddi.raw
      │
-     ▼
-reboot → installed Bluefin Server
+     ├─ bootctl install --esp-path=/mnt/esp --root=/mnt/root
+     │      installs systemd-boot + OS UKI into the new ESP
+     │
+     └─ systemctl poweroff
+          │
+          ▼
+     Reboot into installed Bluefin Server
 ```
 
-## Installer live environment (`installer-stack.bst`)
+## Target disk detection
 
-NOT distroless — the installer needs tools and a shell.
+The `bluefin-install` script auto-detects the first writable non-removable
+block device (`/dev/vda`, `/dev/sda`, `/dev/nvme0n1`, `/dev/mmcblk0`).
+To override, pass `installer.disk=/dev/TARGET` on the kernel cmdline.
 
-| Component | Purpose |
-|---|---|
-| `systemd.bst` | repart + sysupdate + firstboot + bootctl |
-| `cryptsetup.bst` | LUKS partition support |
-| `dracut.bst` | initrd generation (see UKI stub) |
-| `kernel-server.bst` | installer kernel |
-| `installer-repart.bst` | repart.d staging → /usr/lib/repart.d/ |
-| `installer-sysupdate.bst` | sysupdate.d staging → /usr/lib/sysupdate.d/ |
+## Secure Boot signing (opt-in)
 
-## sysupdate.d transfer config (`bluefin-server-ddi.conf`)
+The installer UKI is produced unsigned by default. To produce a signed UKI:
+
+```bash
+# Add to ukify build invocation in bluefin-server-installer.bst:
+--secureboot-private-key=/path/to/vendor.key \
+--secureboot-certificate=/path/to/vendor.crt
+```
+
+Inject the key files as BST secrets or CI secrets. The FSDK pattern for this
+is in `elements/vm/minimal-secure/signed-boot.bst` (uses `kind: local` sources
+for the key files — keep those out of the repo).
+
+## sysupdate.d transfer config
 
 ```ini
-[Transfer]
-ProtectVersion=%A
-
 [Source]
 Type=url-file
 Path=https://github.com/castrojo/bluefin-server/releases/download/
@@ -107,76 +162,41 @@ MatchPattern=bluefin-server-ddi-@v.raw
 CurrentSymlink=/run/installer/bluefin-server-ddi.raw
 ```
 
-`CopyBlocks=/run/installer/bluefin-server-ddi.raw` in `20-root-a.conf` reads
-the file that sysupdate deposits at the `CurrentSymlink` path.
+## OS DDI artifact (open item)
 
-## repart.d partition layout (TARGET disk)
+`bluefin-server-ddi-@v.raw.zst` is the erofs partition image that sysupdate
+pulls. It does NOT exist yet. Building it requires:
 
-| Config | Type | Format | Notes |
-|---|---|---|---|
-| `10-esp.conf` | esp | vfat | 500M–1G; bootloader + UKIs go here |
-| `20-root-a.conf` | root | — | DDI applied via `CopyBlocks=` |
-| `30-var.conf` | var | xfs | writable; grows to fill remaining space |
-
-## Remaining stub: UKI generation
-
-The `bluefin-server-installer.bst` script element is stubbed at the step
-that produces `installer.efi`. Replace the `dd` stub with:
-
-```bash
-# Step A: generate the installer initrd via dracut
-dracut \
-  --kver "$(ls /layer/usr/lib/modules | head -1)" \
-  --add "systemd systemd-repart network base" \
-  --no-hostonly \
-  installer.cpio.zst
-
-# Step B: assemble the UKI
-ukify build \
-  --linux="$(ls /layer/usr/lib/modules/*/vmlinuz | head -1)" \
-  --initrd=installer.cpio.zst \
-  --cmdline="systemd.unit=installer.target console=ttyS0,115200" \
-  --output=/layer/boot/efi/EFI/Linux/installer.efi
-```
-
-Required additions to `bluefin-server-installer.bst`:
-- `freedesktop-sdk.bst:components/systemd-ukify.bst` as `build-depends`
-
-**Secure Boot signing decision:**
-- Dev/CI: unsigned UKI — `--secureboot-private-key` not passed, works for USB installs
-- Release: sign with a Bluefin vendor key pair injected at CI time
-
-## Release workflow
-
-`.github/workflows/release-installer.yml` publishes on `installer-v*` tags:
-
-```
-git tag installer-v0.1.0
-git push origin installer-v0.1.0
-```
-
-Uploads to GitHub Releases:
-- `bluefin-server-installer-<ver>.raw.zst`
-- `SHA256SUMS`
-
-The OS DDI (`bluefin-server-ddi-<ver>.raw.zst`) is a separate release artifact
-published by a future `elements/installer/os-snapshot.bst` element once the
-server rootfs DDI packaging is defined (separate todo from UKI generation).
+1. A non-bootc server rootfs stack (strip ostree/composefs/bootc from
+   `bluefin-server/os-stack.bst` → new `elements/installer/server-rootfs-stack.bst`)
+2. An erofs image element:
+   ```bash
+   mkfs.erofs --all-root bluefin-server-ddi.raw /layer
+   zstd --rm -T0 -19 bluefin-server-ddi.raw -o bluefin-server-ddi-<ver>.raw.zst
+   ```
+3. A corresponding `elements/oci/bluefin-server-ddi.bst` script element
+4. Adding the DDI artifact to `release-installer.yml`
 
 ## Justfile commands
 
 ```
 just validate-installer    # resolve element graph — works today
-just build-installer       # build .raw.zst (stub until UKI wired)
-just export-installer      # export artifacts to dist/
+just build-installer       # full build: cpio + ukify + systemd-repart
+just export-installer      # export .raw.zst + SHA256SUMS to dist/
 ```
+
+## Release
+
+`.github/workflows/release-installer.yml` publishes on `installer-v*` tags:
+```
+git tag installer-v0.1.0 && git push origin installer-v0.1.0
+```
+Uploads `bluefin-server-installer-<ver>.raw.zst` + `SHA256SUMS`.
 
 ## Related
 
-- `docs/skills/nspawn-machine-image.md` — the tarball artifact pattern that
-  this release workflow mirrors
-- `elements/oci/brew-nspawn.bst` — reference script element producing a
-  non-OCI release artifact
-- FSDK `elements/vm/minimal-secure/sysupdate-config.bst` — FSDK's own
-  sysupdate.d wiring pattern
+- `docs/skills/nspawn-machine-image.md` — tarball artifact pattern
+- `elements/oci/brew-nspawn.bst` — reference for non-OCI script elements
+- FSDK `elements/vm/minimal-secure/` — repart + ukify toolchain reference
+
 

--- a/docs/skills/ddi-installer.md
+++ b/docs/skills/ddi-installer.md
@@ -3,147 +3,180 @@
 ## What this is
 
 A DDI (Discoverable Disk Image) based live installer for Bluefin Server.
-When booted, it runs `systemd-repart` to partition a target disk and copy
-the OS DDI payload to it. No bootc, no OCI pull — purely systemd-native.
+No bootc, no OCI image pull — purely systemd-native network-pull model:
+
+1. Boot from the installer USB (a GPT disk image with one ESP partition)
+2. The installer live env runs `systemd-sysupdate` to pull the OS DDI from
+   GitHub Releases
+3. `systemd-repart` applies the DDI to the target disk
+4. `bootctl install` + `systemd-firstboot` provision the bootloader and
+   initial configuration
+5. Reboot into the installed OS
 
 ## Status
 
-**Scaffolded — two blockers before it builds.** See TODOs below.
+**Scaffolded — one remaining stub before it produces a real bootable image.**
 
-## Design
+- ✅ Element chain defined and graph resolves (`just validate-installer`)
+- ✅ sysupdate.d transfer config wired (pulls OS DDI from GitHub Releases)
+- ✅ repart.d target disk layout defined
+- ✅ Release workflow wired (`.github/workflows/release-installer.yml`)
+- 🔲 UKI generation (dracut initrd + ukify — see stub section below)
 
-### Element chain
+## Element chain
 
 ```
 elements/
   installer/
-    installer-stack.bst       kind: stack  — live installer env deps
-    installer-repart.bst      kind: import — repart.d configs (target disk layout)
+    installer-stack.bst      kind: stack  — live installer env deps
+    installer-repart.bst     kind: import — repart.d configs (target disk layout)
+    installer-sysupdate.bst  kind: import — sysupdate.d transfer config
   oci/
-    bluefin-server-installer.bst  kind: script — produces .raw + SHA256SUMS
+    bluefin-server-installer.bst  kind: script — produces .raw.zst + SHA256SUMS
 files/
   installer/
     repart.d/
       10-esp.conf             EFI System Partition (500M–1G, vfat)
-      20-root-a.conf          Root slot A (erofs DDI payload via CopyBlocks=auto)
+      20-root-a.conf          Root slot A (CopyBlocks from sysupdate download)
       30-var.conf             /var (xfs, grows to fill disk)
+    sysupdate.d/
+      bluefin-server-ddi.conf sysupdate transfer config (url-file, GitHub Releases)
 ```
 
-### Installer live environment (`installer-stack.bst`)
+## Network-pull install flow
 
-The live installer is NOT distroless — it keeps bash and tooling.
-Key components:
-- `freedesktop-sdk.bst:components/systemd.bst` — full systemd includes
-  `systemd-repart`, `systemd-firstboot`, and `bootctl`
-- `freedesktop-sdk.bst:components/cryptsetup.bst` — LUKS partition support
-- `freedesktop-sdk.bst:components/erofs-utils.bst` — erofs DDI creation
-- `freedesktop-sdk.bst:components/dracut.bst` — initrd generation
-- `bluefin-server/kernel-server.bst` — the installer kernel
+```
+Installer boot
+     │
+     ▼
+installer.efi (UKI: kernel + initrd)
+     │
+     ▼
+systemd-sysupdate --definitions=/usr/lib/sysupdate.d update
+     │  reads: files/installer/sysupdate.d/bluefin-server-ddi.conf
+     │  fetches: bluefin-server-ddi-<ver>.raw.zst from GitHub Releases
+     │  verifies: SHA256SUMS
+     │  writes: /run/installer/bluefin-server-ddi-<ver>.raw
+     │  symlinks: /run/installer/bluefin-server-ddi.raw → versioned file
+     │
+     ▼
+systemd-repart --dry-run=no /dev/TARGET
+     │  reads: /usr/lib/repart.d/ (10-esp, 20-root-a, 30-var)
+     │  20-root-a.conf: CopyBlocks=/run/installer/bluefin-server-ddi.raw
+     │  creates ESP, root-a partition (DDI copied), var partition
+     │
+     ▼
+bootctl install --esp-path=/dev/TARGET-esp-partition
+     │
+     ▼
+systemd-firstboot (hostname, locale, credentials)
+     │
+     ▼
+reboot → installed Bluefin Server
+```
 
-### Disk image output (`bluefin-server-installer.bst`)
+## Installer live environment (`installer-stack.bst`)
 
-The final artifact is a GPT disk image produced by `systemd-repart --empty=create`.
-It contains:
-1. ESP (vfat) — installer UKI at `/EFI/Linux/installer.efi`
-2. Data partition — OS DDI erofs image (`bluefin-server-root.erofs`)
+NOT distroless — the installer needs tools and a shell.
 
-When booted, the installer UKI starts a systemd initrd that:
-1. Finds the target disk (via kernel cmdline or interactive prompt)
-2. Runs `systemd-repart --dry-run=no TARGET_DISK` with the bundled `repart.d`
-3. Calls `bootctl install` to install systemd-boot into the new ESP
-4. Runs `systemd-firstboot` for hostname/locale/credentials
-5. Reboots into the installed OS
+| Component | Purpose |
+|---|---|
+| `systemd.bst` | repart + sysupdate + firstboot + bootctl |
+| `cryptsetup.bst` | LUKS partition support |
+| `dracut.bst` | initrd generation (see UKI stub) |
+| `kernel-server.bst` | installer kernel |
+| `installer-repart.bst` | repart.d staging → /usr/lib/repart.d/ |
+| `installer-sysupdate.bst` | sysupdate.d staging → /usr/lib/sysupdate.d/ |
 
-### repart.d partition layout (TARGET disk)
+## sysupdate.d transfer config (`bluefin-server-ddi.conf`)
+
+```ini
+[Transfer]
+ProtectVersion=%A
+
+[Source]
+Type=url-file
+Path=https://github.com/castrojo/bluefin-server/releases/download/
+MatchPattern=bluefin-server-ddi-@v.raw.zst
+SHA256Sum=SHA256SUMS
+
+[Target]
+Type=regular-file
+Path=/run/installer/
+MatchPattern=bluefin-server-ddi-@v.raw
+CurrentSymlink=/run/installer/bluefin-server-ddi.raw
+```
+
+`CopyBlocks=/run/installer/bluefin-server-ddi.raw` in `20-root-a.conf` reads
+the file that sysupdate deposits at the `CurrentSymlink` path.
+
+## repart.d partition layout (TARGET disk)
 
 | Config | Type | Format | Notes |
 |---|---|---|---|
-| `10-esp.conf` | esp | vfat | 500M–1G; bootloader lives here |
-| `20-root-a.conf` | root | erofs | DDI payload copied via `CopyBlocks=auto` |
+| `10-esp.conf` | esp | vfat | 500M–1G; bootloader + UKIs go here |
+| `20-root-a.conf` | root | — | DDI applied via `CopyBlocks=` |
 | `30-var.conf` | var | xfs | writable; grows to fill remaining space |
 
-`CopyBlocks=auto` in `20-root-a.conf` tells systemd-repart to find the
-matching DDI source from `/run/repart-sources/` — the initrd populates
-this dir by loopback-mounting the OS DDI partition from the installer media.
+## Remaining stub: UKI generation
 
-## Blockers
+The `bluefin-server-installer.bst` script element is stubbed at the step
+that produces `installer.efi`. Replace the `dd` stub with:
 
-### Blocker 1: UKI generation
+```bash
+# Step A: generate the installer initrd via dracut
+dracut \
+  --kver "$(ls /layer/usr/lib/modules | head -1)" \
+  --add "systemd systemd-repart network base" \
+  --no-hostonly \
+  installer.cpio.zst
 
-The installer needs a UKI (`installer.efi`) containing:
-- kernel: from `bluefin-server/kernel-server.bst`
-- initrd: built by dracut against `installer-stack.bst`
-- cmdline: `systemd.unit=installer.target console=ttyS0,115200`
-
-Build command (once inputs exist):
-```
+# Step B: assemble the UKI
 ukify build \
-  --linux=$(ls /layer/usr/lib/modules/*/vmlinuz | head -1) \
+  --linux="$(ls /layer/usr/lib/modules/*/vmlinuz | head -1)" \
   --initrd=installer.cpio.zst \
   --cmdline="systemd.unit=installer.target console=ttyS0,115200" \
   --output=/layer/boot/efi/EFI/Linux/installer.efi
 ```
 
-**Decision needed:** Secure Boot signing for the installer UKI?
-- Dev/CI: unsigned (acceptable — installer is not the installed OS)
-- Release: sign with `freedesktop-sdk.bst:components/systemd-ukify.bst` +
-  a Bluefin vendor key pair (store separately, inject at CI time)
+Required additions to `bluefin-server-installer.bst`:
+- `freedesktop-sdk.bst:components/systemd-ukify.bst` as `build-depends`
 
-Add `freedesktop-sdk.bst:components/systemd-ukify.bst` as a `build-depends`
-in `bluefin-server-installer.bst` once this is resolved.
+**Secure Boot signing decision:**
+- Dev/CI: unsigned UKI — `--secureboot-private-key` not passed, works for USB installs
+- Release: sign with a Bluefin vendor key pair injected at CI time
 
-### Blocker 2: OS DDI payload format
+## Release workflow
 
-The `20-root-a.conf` repart config uses `CopyBlocks=auto`. This requires a
-source DDI image that `systemd-repart` can find at install time.
+`.github/workflows/release-installer.yml` publishes on `installer-v*` tags:
 
-**Options:**
+```
+git tag installer-v0.1.0
+git push origin installer-v0.1.0
+```
 
-**A. erofs image in a data partition of the installer media** (recommended)
-  - Build `elements/installer/os-snapshot.bst` (kind: script):
-    ```
-    mkfs.erofs --all-root bluefin-server-root.erofs /layer
-    ```
-    where `/layer` is a non-bootc OS stack (new element needed)
-  - The installer disk gets a second partition containing this erofs image
-  - The installer initrd loopback-mounts it and exposes it via
-    `/run/repart-sources/`
-  - **Sub-blocker**: the OS stack for DDI must drop ostree/composefs/bootc
-    deps from `bluefin-server/os-stack.bst`. Needs a separate stack element,
-    e.g. `elements/installer/server-rootfs-stack.bst`.
+Uploads to GitHub Releases:
+- `bluefin-server-installer-<ver>.raw.zst`
+- `SHA256SUMS`
 
-**B. Network pull via systemd-sysupdate** (simpler installer, larger attack surface)
-  - No data partition needed
-  - Installer initrd runs `systemd-sysupdate` to pull the OS DDI from
-    GitHub Releases
-  - Requires network during installation
-  - The sysupdate transfer config would be baked into the installer
-
-**Decision needed:** Option A (offline, bigger installer) or B (network required)?
+The OS DDI (`bluefin-server-ddi-<ver>.raw.zst`) is a separate release artifact
+published by a future `elements/installer/os-snapshot.bst` element once the
+server rootfs DDI packaging is defined (separate todo from UKI generation).
 
 ## Justfile commands
 
 ```
 just validate-installer    # resolve element graph — works today
-just build-installer       # build stub .raw (stub until blockers resolved)
-just export-installer      # export .raw + SHA256SUMS to dist/
+just build-installer       # build .raw.zst (stub until UKI wired)
+just export-installer      # export artifacts to dist/
 ```
-
-## Element references
-
-All FSDK element references use the junction override in
-`elements/freedesktop-sdk.bst`, which redirects:
-- `components/systemd.bst` → `gnome-build-meta.bst:core-deps/systemd.bst`
-- `components/systemd-ukify.bst` → `gnome-build-meta.bst:core-deps/systemd-ukify.bst`
-
-This is inherited automatically — no special handling needed in installer
-elements.
 
 ## Related
 
-- `docs/skills/nspawn-machine-image.md` — the tarball artifact pattern
-  (brew-nspawn.bst) that `bluefin-server-installer.bst` is modeled after
-- `elements/oci/brew-nspawn.bst` — reference script element producing
-  a non-OCI release artifact
-- FSDK `elements/vm/minimal-secure/` — FSDK's own secure-boot VM image
-  that uses the same repart + ukify toolchain
+- `docs/skills/nspawn-machine-image.md` — the tarball artifact pattern that
+  this release workflow mirrors
+- `elements/oci/brew-nspawn.bst` — reference script element producing a
+  non-OCI release artifact
+- FSDK `elements/vm/minimal-secure/sysupdate-config.bst` — FSDK's own
+  sysupdate.d wiring pattern
+

--- a/docs/skills/ddi-installer.md
+++ b/docs/skills/ddi-installer.md
@@ -151,7 +151,7 @@ for the key files — keep those out of the repo).
 ```ini
 [Source]
 Type=url-file
-Path=https://github.com/castrojo/bluefin-server/releases/download/
+Path=https://github.com/projectbluefin/server/releases/download/
 MatchPattern=bluefin-server-ddi-@v.raw.zst
 SHA256Sum=SHA256SUMS
 
@@ -214,5 +214,4 @@ The lab is responsible for:
 - `docs/skills/nspawn-machine-image.md` — tarball artifact pattern
 - `elements/oci/brew-nspawn.bst` — reference for non-OCI script elements
 - FSDK `elements/vm/minimal-secure/` — repart + ukify toolchain reference
-
 

--- a/docs/skills/ddi-installer.md
+++ b/docs/skills/ddi-installer.md
@@ -14,15 +14,15 @@ No bootc, no OCI image pull, no dracut — purely systemd-native:
 
 ## Status
 
-**Fully wired — no remaining stubs.** `just validate-installer` passes.
+**Partially wired.** Installer media pipeline is wired; OS DDI artifact lane is still pending.
 
 - ✅ Dracut-free cpio initrd assembled inline by the BST script element
 - ✅ UKI built with `ukify` (unsigned; Secure Boot signing is opt-in)
 - ✅ sysupdate.d transfer config pulls OS DDI from GitHub Releases
 - ✅ repart.d target disk layout defined
 - ✅ `bluefin-install` orchestration script (sysupdate → repart → bootctl)
-- ✅ Release workflow (`.github/workflows/release-installer.yml`)
-- 🔲 OS DDI artifact (`bluefin-server-ddi-@v.raw.zst`) — separate todo
+- ✅ Release dispatch workflow (`.github/workflows/release-installer.yml`) delegates installer build to testing-lab
+- 🔲 OS DDI artifact (`bluefin-server-ddi-@v.raw.zst`) — still required for full install path
 
 ## Element chain
 
@@ -214,4 +214,3 @@ The lab is responsible for:
 - `docs/skills/nspawn-machine-image.md` — tarball artifact pattern
 - `elements/oci/brew-nspawn.bst` — reference for non-OCI script elements
 - FSDK `elements/vm/minimal-secure/` — repart + ukify toolchain reference
-

--- a/docs/skills/ddi-installer.md
+++ b/docs/skills/ddi-installer.md
@@ -1,0 +1,149 @@
+# DDI Live Installer
+
+## What this is
+
+A DDI (Discoverable Disk Image) based live installer for Bluefin Server.
+When booted, it runs `systemd-repart` to partition a target disk and copy
+the OS DDI payload to it. No bootc, no OCI pull — purely systemd-native.
+
+## Status
+
+**Scaffolded — two blockers before it builds.** See TODOs below.
+
+## Design
+
+### Element chain
+
+```
+elements/
+  installer/
+    installer-stack.bst       kind: stack  — live installer env deps
+    installer-repart.bst      kind: import — repart.d configs (target disk layout)
+  oci/
+    bluefin-server-installer.bst  kind: script — produces .raw + SHA256SUMS
+files/
+  installer/
+    repart.d/
+      10-esp.conf             EFI System Partition (500M–1G, vfat)
+      20-root-a.conf          Root slot A (erofs DDI payload via CopyBlocks=auto)
+      30-var.conf             /var (xfs, grows to fill disk)
+```
+
+### Installer live environment (`installer-stack.bst`)
+
+The live installer is NOT distroless — it keeps bash and tooling.
+Key components:
+- `freedesktop-sdk.bst:components/systemd.bst` — full systemd includes
+  `systemd-repart`, `systemd-firstboot`, and `bootctl`
+- `freedesktop-sdk.bst:components/cryptsetup.bst` — LUKS partition support
+- `freedesktop-sdk.bst:components/erofs-utils.bst` — erofs DDI creation
+- `freedesktop-sdk.bst:components/dracut.bst` — initrd generation
+- `bluefin-server/kernel-server.bst` — the installer kernel
+
+### Disk image output (`bluefin-server-installer.bst`)
+
+The final artifact is a GPT disk image produced by `systemd-repart --empty=create`.
+It contains:
+1. ESP (vfat) — installer UKI at `/EFI/Linux/installer.efi`
+2. Data partition — OS DDI erofs image (`bluefin-server-root.erofs`)
+
+When booted, the installer UKI starts a systemd initrd that:
+1. Finds the target disk (via kernel cmdline or interactive prompt)
+2. Runs `systemd-repart --dry-run=no TARGET_DISK` with the bundled `repart.d`
+3. Calls `bootctl install` to install systemd-boot into the new ESP
+4. Runs `systemd-firstboot` for hostname/locale/credentials
+5. Reboots into the installed OS
+
+### repart.d partition layout (TARGET disk)
+
+| Config | Type | Format | Notes |
+|---|---|---|---|
+| `10-esp.conf` | esp | vfat | 500M–1G; bootloader lives here |
+| `20-root-a.conf` | root | erofs | DDI payload copied via `CopyBlocks=auto` |
+| `30-var.conf` | var | xfs | writable; grows to fill remaining space |
+
+`CopyBlocks=auto` in `20-root-a.conf` tells systemd-repart to find the
+matching DDI source from `/run/repart-sources/` — the initrd populates
+this dir by loopback-mounting the OS DDI partition from the installer media.
+
+## Blockers
+
+### Blocker 1: UKI generation
+
+The installer needs a UKI (`installer.efi`) containing:
+- kernel: from `bluefin-server/kernel-server.bst`
+- initrd: built by dracut against `installer-stack.bst`
+- cmdline: `systemd.unit=installer.target console=ttyS0,115200`
+
+Build command (once inputs exist):
+```
+ukify build \
+  --linux=$(ls /layer/usr/lib/modules/*/vmlinuz | head -1) \
+  --initrd=installer.cpio.zst \
+  --cmdline="systemd.unit=installer.target console=ttyS0,115200" \
+  --output=/layer/boot/efi/EFI/Linux/installer.efi
+```
+
+**Decision needed:** Secure Boot signing for the installer UKI?
+- Dev/CI: unsigned (acceptable — installer is not the installed OS)
+- Release: sign with `freedesktop-sdk.bst:components/systemd-ukify.bst` +
+  a Bluefin vendor key pair (store separately, inject at CI time)
+
+Add `freedesktop-sdk.bst:components/systemd-ukify.bst` as a `build-depends`
+in `bluefin-server-installer.bst` once this is resolved.
+
+### Blocker 2: OS DDI payload format
+
+The `20-root-a.conf` repart config uses `CopyBlocks=auto`. This requires a
+source DDI image that `systemd-repart` can find at install time.
+
+**Options:**
+
+**A. erofs image in a data partition of the installer media** (recommended)
+  - Build `elements/installer/os-snapshot.bst` (kind: script):
+    ```
+    mkfs.erofs --all-root bluefin-server-root.erofs /layer
+    ```
+    where `/layer` is a non-bootc OS stack (new element needed)
+  - The installer disk gets a second partition containing this erofs image
+  - The installer initrd loopback-mounts it and exposes it via
+    `/run/repart-sources/`
+  - **Sub-blocker**: the OS stack for DDI must drop ostree/composefs/bootc
+    deps from `bluefin-server/os-stack.bst`. Needs a separate stack element,
+    e.g. `elements/installer/server-rootfs-stack.bst`.
+
+**B. Network pull via systemd-sysupdate** (simpler installer, larger attack surface)
+  - No data partition needed
+  - Installer initrd runs `systemd-sysupdate` to pull the OS DDI from
+    GitHub Releases
+  - Requires network during installation
+  - The sysupdate transfer config would be baked into the installer
+
+**Decision needed:** Option A (offline, bigger installer) or B (network required)?
+
+## Justfile commands
+
+```
+just validate-installer    # resolve element graph — works today
+just build-installer       # build stub .raw (stub until blockers resolved)
+just export-installer      # export .raw + SHA256SUMS to dist/
+```
+
+## Element references
+
+All FSDK element references use the junction override in
+`elements/freedesktop-sdk.bst`, which redirects:
+- `components/systemd.bst` → `gnome-build-meta.bst:core-deps/systemd.bst`
+- `components/systemd-ukify.bst` → `gnome-build-meta.bst:core-deps/systemd-ukify.bst`
+
+This is inherited automatically — no special handling needed in installer
+elements.
+
+## Related
+
+- `docs/skills/nspawn-machine-image.md` — the tarball artifact pattern
+  (brew-nspawn.bst) that `bluefin-server-installer.bst` is modeled after
+- `elements/oci/brew-nspawn.bst` — reference script element producing
+  a non-OCI release artifact
+- FSDK `elements/vm/minimal-secure/` — FSDK's own secure-boot VM image
+  that uses the same repart + ukify toolchain

--- a/elements/installer/installer-repart.bst
+++ b/elements/installer/installer-repart.bst
@@ -1,0 +1,18 @@
+kind: import
+description: |
+  Installs the repart.d partition definitions into /usr/lib/repart.d/ inside
+  the live installer environment. When the installer runs
+  "systemd-repart --dry-run=no DEVICE", it reads these configs to know how
+  to partition and populate the TARGET disk.
+
+  Partition layout:
+    10-esp.conf          EFI System Partition (vfat, 500M–1G)
+    20-root-a.conf       Root slot A — erofs DDI payload copied here
+    30-var.conf          /var — xfs, writable, grows to fill disk
+
+sources:
+  - kind: local
+    path: files/installer/repart.d
+
+config:
+  target: /usr/lib/repart.d

--- a/elements/installer/installer-stack.bst
+++ b/elements/installer/installer-stack.bst
@@ -1,0 +1,37 @@
+kind: stack
+description: |
+  Live installer environment stack. Provides systemd (with systemd-repart,
+  systemd-firstboot, bootctl), cryptsetup, erofs-utils, dracut, and the
+  server kernel. NOT distroless — the installer needs tools and a shell.
+
+  NOTE: This is the build-time staging stack. The UKI (installer.efi) is
+  generated separately from this; see elements/oci/bluefin-server-installer.bst
+  for the TODO on UKI/initrd generation.
+
+depends:
+  # Base runtime
+  - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+  - freedesktop-sdk.bst:components/ca-certificates.bst
+  - freedesktop-sdk.bst:components/tzdata.bst
+  - freedesktop-sdk.bst:integration/extra-fs.bst
+  - freedesktop-sdk.bst:integration/ldconfig.bst
+
+  # systemd full (includes systemd-repart, systemd-firstboot, bootctl)
+  # gnome-build-meta's systemd is used via the junction override in
+  # elements/freedesktop-sdk.bst — no special reference needed here.
+  - freedesktop-sdk.bst:components/systemd.bst
+  - freedesktop-sdk.bst:components/kmod.bst
+  - freedesktop-sdk.bst:components/shadow.bst
+
+  # Disk setup tools
+  - freedesktop-sdk.bst:components/cryptsetup.bst  # LUKS partition support
+  - freedesktop-sdk.bst:components/erofs-utils.bst  # mkfs.erofs for DDI payload
+
+  # initrd generator — dracut wires repart + firstboot into the live initrd
+  - freedesktop-sdk.bst:components/dracut.bst
+
+  # Kernel (installer boots from this)
+  - bluefin-server/kernel-server.bst
+
+  # repart.d configs describing the TARGET disk layout
+  - installer/installer-repart.bst

--- a/elements/installer/installer-stack.bst
+++ b/elements/installer/installer-stack.bst
@@ -1,15 +1,15 @@
 kind: stack
 description: |
   Live installer environment stack. Provides systemd (with systemd-repart,
-  systemd-firstboot, bootctl, systemd-sysupdate), cryptsetup, dracut, and the
-  server kernel. NOT distroless — the installer needs tools and a shell.
+  systemd-firstboot, bootctl, systemd-sysupdate), cryptsetup, and the server
+  kernel. NOT distroless — the installer needs tools and a shell.
+
+  No dracut: the initrd is assembled directly from this rootfs via cpio in
+  bluefin-server-installer.bst. This keeps the toolchain minimal and removes
+  the dracut dependency chain.
 
   The installer uses systemd-sysupdate to pull the OS DDI from GitHub Releases
   over the network, then systemd-repart applies it to the target disk.
-
-  NOTE: This is the build-time staging stack. The UKI (installer.efi) is
-  generated separately from this; see elements/oci/bluefin-server-installer.bst
-  for the TODO on UKI/initrd generation.
 
 depends:
   # Base runtime
@@ -28,10 +28,7 @@ depends:
   # Disk setup: LUKS partition support during install
   - freedesktop-sdk.bst:components/cryptsetup.bst
 
-  # initrd generator — dracut wires repart + sysupdate into the live initrd
-  - freedesktop-sdk.bst:components/dracut.bst
-
-  # Kernel (installer boots from this)
+  # Kernel (installer boots from this; vmlinuz used as the UKI --linux= arg)
   - bluefin-server/kernel-server.bst
 
   # repart.d configs describing the TARGET disk layout
@@ -39,4 +36,8 @@ depends:
 
   # sysupdate.d transfer config for pulling the OS DDI from GitHub Releases
   - installer/installer-sysupdate.bst
+
+  # Installer systemd units (installer.target + installer.service)
+  - installer/installer-units.bst
+
 

--- a/elements/installer/installer-stack.bst
+++ b/elements/installer/installer-stack.bst
@@ -1,8 +1,11 @@
 kind: stack
 description: |
   Live installer environment stack. Provides systemd (with systemd-repart,
-  systemd-firstboot, bootctl), cryptsetup, erofs-utils, dracut, and the
+  systemd-firstboot, bootctl, systemd-sysupdate), cryptsetup, dracut, and the
   server kernel. NOT distroless — the installer needs tools and a shell.
+
+  The installer uses systemd-sysupdate to pull the OS DDI from GitHub Releases
+  over the network, then systemd-repart applies it to the target disk.
 
   NOTE: This is the build-time staging stack. The UKI (installer.efi) is
   generated separately from this; see elements/oci/bluefin-server-installer.bst
@@ -16,18 +19,16 @@ depends:
   - freedesktop-sdk.bst:integration/extra-fs.bst
   - freedesktop-sdk.bst:integration/ldconfig.bst
 
-  # systemd full (includes systemd-repart, systemd-firstboot, bootctl)
-  # gnome-build-meta's systemd is used via the junction override in
-  # elements/freedesktop-sdk.bst — no special reference needed here.
+  # systemd full (includes systemd-repart, systemd-firstboot, bootctl,
+  # and systemd-sysupdate for network DDI pull)
   - freedesktop-sdk.bst:components/systemd.bst
   - freedesktop-sdk.bst:components/kmod.bst
   - freedesktop-sdk.bst:components/shadow.bst
 
-  # Disk setup tools
-  - freedesktop-sdk.bst:components/cryptsetup.bst  # LUKS partition support
-  - freedesktop-sdk.bst:components/erofs-utils.bst  # mkfs.erofs for DDI payload
+  # Disk setup: LUKS partition support during install
+  - freedesktop-sdk.bst:components/cryptsetup.bst
 
-  # initrd generator — dracut wires repart + firstboot into the live initrd
+  # initrd generator — dracut wires repart + sysupdate into the live initrd
   - freedesktop-sdk.bst:components/dracut.bst
 
   # Kernel (installer boots from this)
@@ -35,3 +36,7 @@ depends:
 
   # repart.d configs describing the TARGET disk layout
   - installer/installer-repart.bst
+
+  # sysupdate.d transfer config for pulling the OS DDI from GitHub Releases
+  - installer/installer-sysupdate.bst
+

--- a/elements/installer/installer-sysupdate.bst
+++ b/elements/installer/installer-sysupdate.bst
@@ -1,0 +1,13 @@
+kind: import
+description: |
+  Installs the sysupdate.d transfer config into /usr/lib/sysupdate.d/ inside
+  the live installer environment. The installer service calls:
+    systemd-sysupdate --definitions=/usr/lib/sysupdate.d update
+  to pull the OS DDI from GitHub Releases before running systemd-repart.
+
+sources:
+  - kind: local
+    path: files/installer/sysupdate.d
+
+config:
+  target: /usr/lib/sysupdate.d

--- a/elements/installer/installer-units.bst
+++ b/elements/installer/installer-units.bst
@@ -1,0 +1,12 @@
+kind: import
+description: |
+  Installs installer.target and installer.service into /usr/lib/systemd/system/
+  inside the live installer environment. These units orchestrate the install
+  sequence: network-online -> sysupdate (pull DDI) -> installer script -> poweroff.
+
+sources:
+  - kind: local
+    path: files/installer/units
+
+config:
+  target: /usr/lib/systemd/system

--- a/elements/oci/bluefin-server-installer.bst
+++ b/elements/oci/bluefin-server-installer.bst
@@ -4,45 +4,32 @@ description: |
 
   Output: bluefin-server-installer-<ver>.raw.zst + SHA256SUMS
 
-  The installer is a single-partition GPT disk image:
-    - partition 1: ESP (vfat) — contains installer.efi (UKI)
+  Initrd approach: dracut-free, cpio-native.
+  The installer-stack rootfs is packed directly into a cpio.zst initrd using
+  POSIX find + cpio. No initrd generator is needed — systemd PID 1 works
+  correctly when the initrd is a plain rootfs cpio with /init -> systemd.
+  This is the approach the systemd project uses for its own test images.
 
-  When booted, installer.efi starts a live systemd initrd that:
-    1. Calls systemd-sysupdate to pull the OS DDI from GitHub Releases
-       (transfer config baked into the installer via installer-sysupdate.bst)
-    2. Runs systemd-repart --dry-run=no DEVICE using the bundled repart.d
-       configs (installer-repart.bst), which write the DDI to the target disk
-    3. Runs bootctl install + systemd-firstboot for initial provisioning
-    4. Reboots into the installed OS
-
-  No OS payload is embedded in the installer — it is pulled by sysupdate at
-  install time. This keeps the installer small (~200MB UKI vs multi-GB media).
-
-  ── REMAINING STUB ──────────────────────────────────────────────────────────
-  TODO: UKI generation (one remaining blocker)
-    The installer.efi UKI must be produced with:
-      ukify build \
-        --linux=$(ls /layer/usr/lib/modules/*/vmlinuz | head -1) \
-        --initrd=installer.cpio.zst \
-        --cmdline="systemd.unit=installer.target console=ttyS0,115200" \
-        --output=/layer/boot/efi/EFI/Linux/installer.efi
-    Requires:
-      a) dracut run against installer-stack to generate installer.cpio.zst
-         (dracut modules needed: systemd systemd-repart network base)
-      b) Add freedesktop-sdk.bst:components/systemd-ukify.bst as build-dep
-      c) Secure Boot signing decision: unsigned works for dev/USB installs;
-         vendor-signed requires a Bluefin key pair injected at CI time.
-    Until resolved the ESP step is stubbed. Replace the dd stub below with
-    the systemd-repart + ukify assembly once dracut integration is confirmed.
-  ────────────────────────────────────────────────────────────────────────────
+  Build pipeline:
+    1. Add /init symlink and bluefin-install script to the staged rootfs
+    2. Link default.target -> installer.target
+    3. Pack rootfs as newc cpio + zstd -> installer.cpio.zst
+    4. ukify build: kernel + cpio.zst -> installer.efi (unsigned UKI)
+    5. systemd-repart --empty=create: assemble single-partition GPT disk
+       (ESP only; the installer pulls the OS DDI over the network at runtime)
+    6. Compress final disk as .raw.zst + SHA256SUMS for GitHub Releases
 
 build-depends:
-  # Toolchain for assembly commands
+  # Toolchain for assembly
   - base/base-stack.bst
-  - freedesktop-sdk.bst:components/zstd.bst
-  # systemd-repart builds the GPT disk image from the staged rootfs + repart.d
+  - freedesktop-sdk.bst:components/cpio.bst      # newc cpio archive creation
+  - freedesktop-sdk.bst:components/findutils.bst  # find for cpio pipe
+  - freedesktop-sdk.bst:components/zstd.bst       # compress initrd + final disk
+  # ukify assembles the UKI (kernel + initrd + cmdline -> .efi)
+  - freedesktop-sdk.bst:components/systemd-ukify.bst
+  # systemd-repart assembles the GPT installer disk image
   - freedesktop-sdk.bst:components/systemd.bst
-  # The installer live-env rootfs (with sysupdate + repart configs), staged at /layer
+  # Installer live-env rootfs staged at /layer
   - filename: installer/installer-stack.bst
     config:
       location: /layer
@@ -52,42 +39,164 @@ variables:
 
 config:
   commands:
-    # ── Step 1: Create the installer ESP layout ──────────────────────────
-    # TODO(UKI): Replace stub with ukify + dracut once initrd generation
-    # is wired. The target path is fixed: /boot/efi/EFI/Linux/installer.efi
+    # ── Step 1: Prepare the initrd rootfs ───────────────────────────────
+    # /init is required by the Linux initrd protocol (kernel hands control
+    # to /init as PID 1). For systemd-native initrds this is a symlink.
     - |
       set -eu
-      mkdir -p /layer/boot/efi/EFI/Linux
-      mkdir -p /layer/boot/efi/EFI/BOOT
-      # ukify build \
-      #   --linux="$(ls /layer/usr/lib/modules/*/vmlinuz | head -1)" \
-      #   --initrd=/installer.cpio.zst \
-      #   --cmdline="systemd.unit=installer.target console=ttyS0,115200" \
-      #   --output=/layer/boot/efi/EFI/Linux/installer.efi
+      # systemd-native initrd: /init -> PID 1
+      ln -sf usr/lib/systemd/systemd /layer/init
+      # Mount points needed by the installer service
+      mkdir -p /layer/efi /layer/mnt/esp /layer/mnt/root /layer/run/installer
 
-    # ── Step 2: Assemble installer GPT disk image via systemd-repart ─────
-    # systemd-repart --empty=create builds a fresh GPT disk from scratch
-    # using the repart.d configs staged under /layer/usr/lib/repart.d/.
-    # When the real UKI exists the dd stub is replaced with this call:
-    #   systemd-repart \
-    #     --empty=create \
-    #     --size=auto \
-    #     --dry-run=no \
-    #     --root=/layer \
-    #     --definitions=/layer/usr/lib/repart.d \
-    #     "%{install-root}/bluefin-server-installer-%{installer-version}.raw"
+    # ── Step 2: Write the bluefin-install orchestration script ──────────
+    # Written inline to avoid a separate import element just for one script.
+    - |
+      set -eu
+      mkdir -p /layer/usr/bin
+      cat > /layer/usr/bin/bluefin-install << 'SCRIPT'
+      #!/bin/bash
+      set -euo pipefail
+      log()  { echo "[bluefin-install] $*"; }
+      fail() { log "ERROR: $*"; exit 1; }
+
+      log "Bluefin Server DDI Installer starting"
+
+      # 1. Pull the OS DDI from GitHub Releases
+      log "Pulling OS DDI via systemd-sysupdate..."
+      systemd-sysupdate --definitions=/usr/lib/sysupdate.d update \
+        || fail "sysupdate failed — check network connectivity and release URL"
+
+      [ -e /run/installer/bluefin-server-ddi.raw ] \
+        || fail "/run/installer/bluefin-server-ddi.raw missing after sysupdate"
+      log "DDI ready: $(ls -lh /run/installer/bluefin-server-ddi.raw)"
+
+      # 2. Detect target disk
+      # Override with installer.disk=<path> on the kernel cmdline if needed.
+      DISK=""
+      for arg in $(cat /proc/cmdline); do
+        case "$arg" in installer.disk=*) DISK="${arg#installer.disk=}" ;; esac
+      done
+      if [ -z "$DISK" ]; then
+        for candidate in /dev/vda /dev/sda /dev/nvme0n1 /dev/mmcblk0; do
+          [ -b "$candidate" ] || continue
+          RO=$(cat "/sys/block/$(basename "$candidate")/ro" 2>/dev/null || echo 1)
+          [ "$RO" = "0" ] && DISK="$candidate" && break
+        done
+      fi
+      [ -n "$DISK" ] \
+        || fail "No writable disk found. Pass installer.disk=/dev/DEVICE on cmdline."
+      log "Target disk: $DISK"
+
+      # 3. Partition and install OS via systemd-repart
+      # Reads /usr/lib/repart.d/:
+      #   10-esp.conf    -> creates vfat ESP (empty; bootloader installed below)
+      #   20-root-a.conf -> creates root partition, copies DDI via CopyBlocks=
+      #   30-var.conf    -> creates /var xfs partition
+      log "Running systemd-repart..."
+      systemd-repart \
+        --dry-run=no \
+        --empty=force \
+        --definitions=/usr/lib/repart.d \
+        "$DISK" \
+        || fail "systemd-repart failed"
+
+      # 4. Install the bootloader into the newly created ESP
+      # Mount ESP and root-a, run bootctl install, then unmount.
+      ESP_DEV=$(lsblk -rno PATH,PARTTYPE "$DISK" 2>/dev/null \
+        | awk '$2 == "c12a7328-f81f-11d2-ba4b-00a0c93ec93b" {print $1}' | head -1)
+      ROOT_DEV=$(lsblk -rno PATH,PARTLABEL "$DISK" 2>/dev/null \
+        | awk '$2 == "bluefin-server-root-a" {print $1}' | head -1)
+
+      if [ -n "$ESP_DEV" ] && [ -n "$ROOT_DEV" ]; then
+        mount "$ESP_DEV"  /mnt/esp
+        mount -o ro "$ROOT_DEV" /mnt/root
+        bootctl install --esp-path=/mnt/esp --root=/mnt/root \
+          || log "WARNING: bootctl install failed (non-fatal)"
+        umount /mnt/esp /mnt/root
+      else
+        log "WARNING: Could not locate ESP ($ESP_DEV) or root ($ROOT_DEV)."
+        log "  Bootloader not installed — run bootctl manually after reboot."
+      fi
+
+      log "Installation complete. Powering off."
+      sleep 2
+      SCRIPT
+      chmod +x /layer/usr/bin/bluefin-install
+
+    # ── Step 3: Wire default.target -> installer.target ─────────────────
+    - |
+      set -eu
+      rm -f /layer/usr/lib/systemd/system/default.target
+      ln -sf installer.target \
+        /layer/usr/lib/systemd/system/default.target
+      # Enable installer.service for the installer.target wants
+      mkdir -p /layer/usr/lib/systemd/system/installer.target.wants
+      ln -sf /usr/lib/systemd/system/installer.service \
+        /layer/usr/lib/systemd/system/installer.target.wants/installer.service
+
+    # ── Step 4: Pack initrd cpio ─────────────────────────────────────────
+    # find . from /layer gives paths like ./usr/bin/... which is exactly
+    # the newc format the kernel expects. The kernel strips the leading dot.
+    - |
+      set -eu
+      ( cd /layer && find . -print0 \
+          | cpio --null --create --format=newc ) \
+        | zstd -T0 -19 -q -o /installer.cpio.zst
+      ls -lh /installer.cpio.zst
+
+    # ── Step 5: Build the UKI ────────────────────────────────────────────
+    # Unsigned UKI — acceptable for USB installer media. Secure Boot
+    # signing can be layered on by passing --secureboot-private-key /
+    # --secureboot-certificate if keys are injected at CI time.
+    - |
+      set -eu
+      KVER=$(ls /layer/usr/lib/modules | head -1)
+      mkdir -p /layer/boot/efi/EFI/Linux
+      ukify build \
+        --linux="/layer/usr/lib/modules/${KVER}/vmlinuz" \
+        --initrd=/installer.cpio.zst \
+        --cmdline="systemd.unit=installer.target console=ttyS0,115200 rw" \
+        --output=/layer/boot/efi/EFI/Linux/installer.efi
+      ls -lh /layer/boot/efi/EFI/Linux/installer.efi
+
+    # ── Step 6: Assemble installer GPT disk image ────────────────────────
+    # installer-stack/repart.d has only 10-esp.conf so the installer media
+    # is a minimal single-partition GPT with just the ESP (+ UKI inside).
+    # The OS DDI is not embedded — it is pulled at install time by sysupdate.
+    #
+    # Note: we use a dedicated repart.d just for the INSTALLER DISK (1 conf:
+    # 10-esp.conf) which is different from the TARGET DISK repart.d (3 confs
+    # staged in /usr/lib/repart.d/ inside the installer rootfs).
     - |
       set -eu
       OUT="%{install-root}"
       FNAME="bluefin-server-installer-%{installer-version}.raw"
-      # Stub until UKI generation is wired — 1MB sparse placeholder.
-      dd if=/dev/zero bs=1M count=1 of="${OUT}/${FNAME}" 2>/dev/null
+      mkdir -p /installer-media-repart.d
+      cat > /installer-media-repart.d/10-esp.conf << 'RCONF'
+      [Partition]
+      Type=esp
+      Format=vfat
+      CopyFiles=/boot/efi:/
+      SizeMinBytes=500M
+      SizeMaxBytes=1G
+      RCONF
+      systemd-repart \
+        --empty=create \
+        --size=auto \
+        --dry-run=no \
+        --root=/layer \
+        --definitions=/installer-media-repart.d \
+        "${OUT}/${FNAME}"
+      ls -lh "${OUT}/${FNAME}"
 
-    # ── Step 3: Compress + checksum for GitHub Releases / sysupdate ──────
+    # ── Step 7: Compress + checksum ──────────────────────────────────────
     - |
       set -eu
       cd "%{install-root}"
       FNAME="bluefin-server-installer-%{installer-version}.raw"
-      zstd --rm -T0 -19 "${FNAME}" -o "${FNAME}.zst"
+      zstd --rm -T0 -19 -q "${FNAME}" -o "${FNAME}.zst"
       sha256sum --binary "${FNAME}.zst" > SHA256SUMS
+      ls -lh
+
 

--- a/elements/oci/bluefin-server-installer.bst
+++ b/elements/oci/bluefin-server-installer.bst
@@ -1,0 +1,100 @@
+kind: script
+description: |
+  Produce the Bluefin Server DDI live installer disk image.
+
+  Output: bluefin-server-installer-<ver>.raw + SHA256SUMS
+
+  The .raw file is a GPT disk image with:
+    - partition 1: ESP (vfat) — contains the installer UKI at /EFI/Linux/
+    - partition 2: data — contains the OS DDI payload (erofs root image)
+
+  When booted, the installer UKI starts a minimal systemd initrd that runs
+  systemd-repart against the target disk using the repart.d configs in
+  /usr/lib/repart.d/, which copy the OS DDI to the installed root slot.
+
+  ── BLOCKERS ────────────────────────────────────────────────────────────────
+  TODO(1): UKI generation
+    The installer.efi UKI must be produced with:
+      ukify build --linux=<vmlinuz> --initrd=<installer.cpio> \
+        --cmdline="systemd.unit=installer.target console=ttyS0,115200"
+    This requires:
+      a) dracut run against the installer-stack to produce installer.cpio
+      b) systemd-ukify available as a build-dep (freedesktop-sdk.bst:components/systemd-ukify.bst)
+      c) A decision on Secure Boot signing: unsigned for dev, vendor-signed for release.
+    Until (a)-(c) are resolved the ESP step below is stubbed out.
+
+  TODO(2): OS DDI payload
+    The erofs OS root image (bluefin-server-root.erofs) must be produced by:
+      mkfs.erofs --all-root bluefin-server-root.erofs /layer
+    where /layer is the staged bluefin-server OS rootfs (without bootc —
+    os-stack.bst minus the ostree/composefs/bootc deps).
+    A new element elements/installer/os-snapshot.bst will produce this.
+    Blocked on: agreement on whether to strip bootc from the OS for DDI.
+  ────────────────────────────────────────────────────────────────────────────
+
+  Once TODO(1) and TODO(2) are resolved, replace the stub commands below with
+  the real UKI + erofs assembly steps.
+
+build-depends:
+  # Toolchain for assembly commands
+  - base/base-stack.bst
+  - freedesktop-sdk.bst:components/tar.bst
+  - freedesktop-sdk.bst:components/zstd.bst
+  # systemd-repart is the tool that assembles the GPT disk image
+  - freedesktop-sdk.bst:components/systemd.bst
+  # erofs-utils needed at build time to create the OS payload image
+  - freedesktop-sdk.bst:components/erofs-utils.bst
+  # The installer live-env rootfs, staged at /layer
+  - filename: installer/installer-stack.bst
+    config:
+      location: /layer
+
+variables:
+  installer-version: "0.1.0"
+
+config:
+  commands:
+    # ── Step 1: Create the installer ESP layout ──────────────────────────
+    # TODO(1): Replace this stub with real UKI generation once dracut
+    # integration and signing decision are resolved. For now, create the
+    # minimum directory structure so systemd-repart can populate the ESP.
+    - |
+      set -eu
+      mkdir -p /layer/boot/efi/EFI/Linux
+      mkdir -p /layer/boot/efi/EFI/BOOT
+      # Placeholder: ukify will write installer.efi here
+      # ukify build \
+      #   --linux=/layer/usr/lib/modules/*/vmlinuz \
+      #   --initrd=/installer.cpio.zst \
+      #   --cmdline="systemd.unit=installer.target console=ttyS0,115200" \
+      #   --output=/layer/boot/efi/EFI/Linux/installer.efi
+
+    # ── Step 2: Produce the installer disk image ─────────────────────────
+    # TODO(2): Add the OS DDI erofs image as partition 2 (data partition).
+    # The final command will be:
+    #   systemd-repart \
+    #     --empty=create \
+    #     --size=auto \
+    #     --dry-run=no \
+    #     --root=/layer \
+    #     --definitions=/usr/lib/repart.d \
+    #     "%{install-root}/bluefin-server-installer-%{installer-version}.raw"
+    #
+    # For now, produce a stub disk image so the element chain can be
+    # validated without building the full OS DDI.
+    - |
+      set -eu
+      OUT="%{install-root}"
+      FNAME="bluefin-server-installer-%{installer-version}.raw"
+      # Stub: 1MB sparse file so `bst show` + validate works without a build.
+      # Replace with the systemd-repart call above once blockers are resolved.
+      dd if=/dev/zero bs=1M count=1 of="${OUT}/${FNAME}" 2>/dev/null
+      echo "NOTE: stub disk image — replace with systemd-repart assembly" \
+           > "${OUT}/INSTALLER_BUILD_STUB.txt"
+
+    # ── Step 3: Checksums for systemd-sysupdate ──────────────────────────
+    - |
+      set -eu
+      cd "%{install-root}"
+      sha256sum --binary "bluefin-server-installer-%{installer-version}.raw" \
+        > SHA256SUMS

--- a/elements/oci/bluefin-server-installer.bst
+++ b/elements/oci/bluefin-server-installer.bst
@@ -2,49 +2,47 @@ kind: script
 description: |
   Produce the Bluefin Server DDI live installer disk image.
 
-  Output: bluefin-server-installer-<ver>.raw + SHA256SUMS
+  Output: bluefin-server-installer-<ver>.raw.zst + SHA256SUMS
 
-  The .raw file is a GPT disk image with:
-    - partition 1: ESP (vfat) — contains the installer UKI at /EFI/Linux/
-    - partition 2: data — contains the OS DDI payload (erofs root image)
+  The installer is a single-partition GPT disk image:
+    - partition 1: ESP (vfat) — contains installer.efi (UKI)
 
-  When booted, the installer UKI starts a minimal systemd initrd that runs
-  systemd-repart against the target disk using the repart.d configs in
-  /usr/lib/repart.d/, which copy the OS DDI to the installed root slot.
+  When booted, installer.efi starts a live systemd initrd that:
+    1. Calls systemd-sysupdate to pull the OS DDI from GitHub Releases
+       (transfer config baked into the installer via installer-sysupdate.bst)
+    2. Runs systemd-repart --dry-run=no DEVICE using the bundled repart.d
+       configs (installer-repart.bst), which write the DDI to the target disk
+    3. Runs bootctl install + systemd-firstboot for initial provisioning
+    4. Reboots into the installed OS
 
-  ── BLOCKERS ────────────────────────────────────────────────────────────────
-  TODO(1): UKI generation
+  No OS payload is embedded in the installer — it is pulled by sysupdate at
+  install time. This keeps the installer small (~200MB UKI vs multi-GB media).
+
+  ── REMAINING STUB ──────────────────────────────────────────────────────────
+  TODO: UKI generation (one remaining blocker)
     The installer.efi UKI must be produced with:
-      ukify build --linux=<vmlinuz> --initrd=<installer.cpio> \
-        --cmdline="systemd.unit=installer.target console=ttyS0,115200"
-    This requires:
-      a) dracut run against the installer-stack to produce installer.cpio
-      b) systemd-ukify available as a build-dep (freedesktop-sdk.bst:components/systemd-ukify.bst)
-      c) A decision on Secure Boot signing: unsigned for dev, vendor-signed for release.
-    Until (a)-(c) are resolved the ESP step below is stubbed out.
-
-  TODO(2): OS DDI payload
-    The erofs OS root image (bluefin-server-root.erofs) must be produced by:
-      mkfs.erofs --all-root bluefin-server-root.erofs /layer
-    where /layer is the staged bluefin-server OS rootfs (without bootc —
-    os-stack.bst minus the ostree/composefs/bootc deps).
-    A new element elements/installer/os-snapshot.bst will produce this.
-    Blocked on: agreement on whether to strip bootc from the OS for DDI.
+      ukify build \
+        --linux=$(ls /layer/usr/lib/modules/*/vmlinuz | head -1) \
+        --initrd=installer.cpio.zst \
+        --cmdline="systemd.unit=installer.target console=ttyS0,115200" \
+        --output=/layer/boot/efi/EFI/Linux/installer.efi
+    Requires:
+      a) dracut run against installer-stack to generate installer.cpio.zst
+         (dracut modules needed: systemd systemd-repart network base)
+      b) Add freedesktop-sdk.bst:components/systemd-ukify.bst as build-dep
+      c) Secure Boot signing decision: unsigned works for dev/USB installs;
+         vendor-signed requires a Bluefin key pair injected at CI time.
+    Until resolved the ESP step is stubbed. Replace the dd stub below with
+    the systemd-repart + ukify assembly once dracut integration is confirmed.
   ────────────────────────────────────────────────────────────────────────────
-
-  Once TODO(1) and TODO(2) are resolved, replace the stub commands below with
-  the real UKI + erofs assembly steps.
 
 build-depends:
   # Toolchain for assembly commands
   - base/base-stack.bst
-  - freedesktop-sdk.bst:components/tar.bst
   - freedesktop-sdk.bst:components/zstd.bst
-  # systemd-repart is the tool that assembles the GPT disk image
+  # systemd-repart builds the GPT disk image from the staged rootfs + repart.d
   - freedesktop-sdk.bst:components/systemd.bst
-  # erofs-utils needed at build time to create the OS payload image
-  - freedesktop-sdk.bst:components/erofs-utils.bst
-  # The installer live-env rootfs, staged at /layer
+  # The installer live-env rootfs (with sysupdate + repart configs), staged at /layer
   - filename: installer/installer-stack.bst
     config:
       location: /layer
@@ -55,46 +53,41 @@ variables:
 config:
   commands:
     # ── Step 1: Create the installer ESP layout ──────────────────────────
-    # TODO(1): Replace this stub with real UKI generation once dracut
-    # integration and signing decision are resolved. For now, create the
-    # minimum directory structure so systemd-repart can populate the ESP.
+    # TODO(UKI): Replace stub with ukify + dracut once initrd generation
+    # is wired. The target path is fixed: /boot/efi/EFI/Linux/installer.efi
     - |
       set -eu
       mkdir -p /layer/boot/efi/EFI/Linux
       mkdir -p /layer/boot/efi/EFI/BOOT
-      # Placeholder: ukify will write installer.efi here
       # ukify build \
-      #   --linux=/layer/usr/lib/modules/*/vmlinuz \
+      #   --linux="$(ls /layer/usr/lib/modules/*/vmlinuz | head -1)" \
       #   --initrd=/installer.cpio.zst \
       #   --cmdline="systemd.unit=installer.target console=ttyS0,115200" \
       #   --output=/layer/boot/efi/EFI/Linux/installer.efi
 
-    # ── Step 2: Produce the installer disk image ─────────────────────────
-    # TODO(2): Add the OS DDI erofs image as partition 2 (data partition).
-    # The final command will be:
+    # ── Step 2: Assemble installer GPT disk image via systemd-repart ─────
+    # systemd-repart --empty=create builds a fresh GPT disk from scratch
+    # using the repart.d configs staged under /layer/usr/lib/repart.d/.
+    # When the real UKI exists the dd stub is replaced with this call:
     #   systemd-repart \
     #     --empty=create \
     #     --size=auto \
     #     --dry-run=no \
     #     --root=/layer \
-    #     --definitions=/usr/lib/repart.d \
+    #     --definitions=/layer/usr/lib/repart.d \
     #     "%{install-root}/bluefin-server-installer-%{installer-version}.raw"
-    #
-    # For now, produce a stub disk image so the element chain can be
-    # validated without building the full OS DDI.
     - |
       set -eu
       OUT="%{install-root}"
       FNAME="bluefin-server-installer-%{installer-version}.raw"
-      # Stub: 1MB sparse file so `bst show` + validate works without a build.
-      # Replace with the systemd-repart call above once blockers are resolved.
+      # Stub until UKI generation is wired — 1MB sparse placeholder.
       dd if=/dev/zero bs=1M count=1 of="${OUT}/${FNAME}" 2>/dev/null
-      echo "NOTE: stub disk image — replace with systemd-repart assembly" \
-           > "${OUT}/INSTALLER_BUILD_STUB.txt"
 
-    # ── Step 3: Checksums for systemd-sysupdate ──────────────────────────
+    # ── Step 3: Compress + checksum for GitHub Releases / sysupdate ──────
     - |
       set -eu
       cd "%{install-root}"
-      sha256sum --binary "bluefin-server-installer-%{installer-version}.raw" \
-        > SHA256SUMS
+      FNAME="bluefin-server-installer-%{installer-version}.raw"
+      zstd --rm -T0 -19 "${FNAME}" -o "${FNAME}.zst"
+      sha256sum --binary "${FNAME}.zst" > SHA256SUMS
+

--- a/files/installer/repart.d/10-esp.conf
+++ b/files/installer/repart.d/10-esp.conf
@@ -1,0 +1,9 @@
+# EFI System Partition
+# bootctl install copies the bootloader here; the installer UKI lands in
+# /EFI/Linux/ so systemd-boot can hand off to the installed OS on reboot.
+[Partition]
+Type=esp
+Format=vfat
+CopyFiles=/boot/efi:/
+SizeMinBytes=500M
+SizeMaxBytes=1G

--- a/files/installer/repart.d/10-esp.conf
+++ b/files/installer/repart.d/10-esp.conf
@@ -1,9 +1,9 @@
 # EFI System Partition
-# bootctl install copies the bootloader here; the installer UKI lands in
-# /EFI/Linux/ so systemd-boot can hand off to the installed OS on reboot.
+# Created empty by systemd-repart; populated post-install by the installer
+# script via: bootctl install --esp-path=<mounted-ESP> --root=<mounted-root>
+# which copies systemd-boot and registers the OS UKI from the installed rootfs.
 [Partition]
 Type=esp
 Format=vfat
-CopyFiles=/boot/efi:/
 SizeMinBytes=500M
 SizeMaxBytes=1G

--- a/files/installer/repart.d/20-root-a.conf
+++ b/files/installer/repart.d/20-root-a.conf
@@ -1,12 +1,12 @@
 # Root partition — slot A
-# systemd-repart copies the DDI payload (erofs image) block-for-block using
-# CopyBlocks=auto, which resolves the nearest .raw with a matching partition
-# type UUID from /run/repart-sources/ (populated by the installer initrd).
-# Verity hash is appended by systemd-repart automatically when the source DDI
-# carries a verity superblock.
+# systemd-repart copies the DDI payload block-for-block from the file that
+# systemd-sysupdate downloaded to /run/installer/bluefin-server-ddi.raw
+# (a stable CurrentSymlink set by the sysupdate transfer config).
+# The source is a raw erofs partition image; repart copies it verbatim.
 [Partition]
 Type=root
 Label=bluefin-server-root-a
-CopyBlocks=auto
+CopyBlocks=/run/installer/bluefin-server-ddi.raw
 SizeMinBytes=4G
 SizeMaxBytes=16G
+

--- a/files/installer/repart.d/20-root-a.conf
+++ b/files/installer/repart.d/20-root-a.conf
@@ -1,0 +1,12 @@
+# Root partition — slot A
+# systemd-repart copies the DDI payload (erofs image) block-for-block using
+# CopyBlocks=auto, which resolves the nearest .raw with a matching partition
+# type UUID from /run/repart-sources/ (populated by the installer initrd).
+# Verity hash is appended by systemd-repart automatically when the source DDI
+# carries a verity superblock.
+[Partition]
+Type=root
+Label=bluefin-server-root-a
+CopyBlocks=auto
+SizeMinBytes=4G
+SizeMaxBytes=16G

--- a/files/installer/repart.d/30-var.conf
+++ b/files/installer/repart.d/30-var.conf
@@ -1,0 +1,11 @@
+# /var partition — writable, persistent across updates
+# FactoryReset=yes: wiped when installer runs with --factory-reset.
+# GrowFileSystem=yes: xfs grows to fill all remaining disk space after
+#   the ESP and root-a partitions are placed.
+[Partition]
+Type=var
+Label=var
+Format=xfs
+FactoryReset=yes
+GrowFileSystem=yes
+SizeMinBytes=4G

--- a/files/installer/sysupdate.d/bluefin-server-ddi.conf
+++ b/files/installer/sysupdate.d/bluefin-server-ddi.conf
@@ -1,0 +1,26 @@
+# DDI payload transfer config for the live installer.
+#
+# The installer live env runs:
+#   systemd-sysupdate --definitions=/usr/lib/sysupdate.d update
+# which fetches the latest bluefin-server-ddi-@v.raw.zst from GitHub Releases,
+# verifies SHA256SUMS, decompresses, and places it at:
+#   /run/installer/bluefin-server-ddi-<ver>.raw
+# with a stable symlink at:
+#   /run/installer/bluefin-server-ddi.raw
+#
+# systemd-repart then reads that symlink via CopyBlocks= in repart.d/20-root-a.conf.
+
+[Transfer]
+ProtectVersion=%A
+
+[Source]
+Type=url-file
+Path=https://github.com/castrojo/bluefin-server/releases/download/
+MatchPattern=bluefin-server-ddi-@v.raw.zst
+SHA256Sum=SHA256SUMS
+
+[Target]
+Type=regular-file
+Path=/run/installer/
+MatchPattern=bluefin-server-ddi-@v.raw
+CurrentSymlink=/run/installer/bluefin-server-ddi.raw

--- a/files/installer/sysupdate.d/bluefin-server-ddi.conf
+++ b/files/installer/sysupdate.d/bluefin-server-ddi.conf
@@ -15,7 +15,7 @@ ProtectVersion=%A
 
 [Source]
 Type=url-file
-Path=https://github.com/castrojo/bluefin-server/releases/download/
+Path=https://github.com/projectbluefin/server/releases/download/
 MatchPattern=bluefin-server-ddi-@v.raw.zst
 SHA256Sum=SHA256SUMS
 

--- a/files/installer/units/installer.service
+++ b/files/installer/units/installer.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Bluefin Server DDI Installer Service
+Documentation=https://github.com/castrojo/bluefin-server
+DefaultDependencies=no
+After=network-online.target
+Wants=network-online.target
+ConditionPathExists=/usr/bin/bluefin-install
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/bluefin-install
+StandardOutput=journal+console
+StandardError=journal+console
+# Power off automatically on success; on failure stay up so the journal is readable.
+SuccessAction=poweroff
+FailureAction=none
+
+[Install]
+WantedBy=installer.target

--- a/files/installer/units/installer.target
+++ b/files/installer/units/installer.target
@@ -1,0 +1,11 @@
+[Unit]
+Description=Bluefin Server Installer
+Documentation=https://github.com/castrojo/bluefin-server
+DefaultDependencies=no
+# Network must be online before the installer runs (sysupdate needs it).
+Wants=network-online.target
+After=network-online.target
+# installer.service does the work; this target waits for it.
+Wants=installer.service
+After=installer.service
+AllowIsolate=yes


### PR DESCRIPTION
## Summary\n- delegate non-PR server build paths to lab dispatch workflows\n- add daily/manual lab release control-plane workflow\n- delegate installer release workflow to lab\n- harden dispatch token scope and workflow input handling\n- update CI/installer/skill docs for the new lab-first flow\n\n## Validation\n- just validate