### PR TITLE
docs: add SECURITY.md vulnerability disclosure policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ See [`AGENTS.md`](AGENTS.md) for the full build matrix and agent skill routing.
 
 See [`CONTRIBUTING.md`](CONTRIBUTING.md) for the contributor checklist and [`docs/skills/index.md`](docs/skills/index.md) for task-specific guidance.
 
+## Security
+
+See [`SECURITY.md`](SECURITY.md) for the vulnerability disclosure policy, supported versions, and how to verify signed release artifacts.
+
 ## Release trust
 
 - GitHub Actions builds all artifacts, signs a combined `SHA256SUMS` manifest, and publishes a GitHub Release.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,73 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Report security vulnerabilities privately through
+[GitHub Private Vulnerability Reporting](https://github.com/projectbluefin/server/security/advisories/new).
+Do **not** open a public GitHub issue for an unpatched vulnerability.
+
+You can also reach the projectbluefin maintainers at **bluefin@projectbluefin.io**
+(the org-wide contact published in
+[`projectbluefin/dakota`](https://github.com/projectbluefin/dakota/blob/main/SECURITY.md)),
+but the GitHub advisory flow is preferred.
+
+Please include:
+
+- A description of the vulnerability and its impact.
+- Reproduction steps or a proof of concept.
+- The affected artifact, stream, or release.
+- A suggested mitigation, if available.
+
+## Response
+
+We follow coordinated disclosure:
+
+- Reports are acknowledged within a few business days.
+- We aim to complete an initial assessment within 7 days.
+- Fix and disclosure timing depends on severity and on coordination with
+  affected upstreams; we keep the reporter informed of progress.
+- Reporters are credited in release notes unless they prefer to remain
+  anonymous.
+
+## Supported Versions
+
+Bluefin Server has no long-term support branches. Versioning is derived from
+the pinned freedesktop-sdk release (run `just version` / `just tags`), and
+`systemd-sysupdate` pulls updates exclusively from the **latest** GitHub
+Release. Only the latest release receives fixes; older point releases are not
+maintained. If you are running an older release, update before reporting — the
+issue may already be fixed.
+
+## Verifying Release Artifacts
+
+Every GitHub Release contains a single combined `SHA256SUMS` manifest and its
+detached, ASCII-armored GPG signature `SHA256SUMS.gpg`, produced by the
+`build-and-release` workflow. Verify a downloaded artifact set with the public
+keyring shipped in this repository:
+
+```sh
+# Download SHA256SUMS and SHA256SUMS.gpg from the release, then:
+gpg --no-default-keyring \
+    --keyring files/os/sysupdate-keys/import-pubring.pgp \
+    --verify SHA256SUMS.gpg SHA256SUMS
+sha256sum --check SHA256SUMS
+```
+
+Running systems verify the same manifest automatically via `systemd-sysupdate`.
+For the full trust model, key rotation, and transfer configuration, see
+[`docs/skills/systemd-sysupdate-verification.md`](docs/skills/systemd-sysupdate-verification.md).
+
+## Scope
+
+This policy covers everything this repository produces and its build pipeline:
+
+- The OS DDI payload, the offline installer disk image, and the k3s
+  `systemd-sysext`.
+- BuildStream elements, build tooling, and GitHub Actions workflows.
+- Release signing and the `systemd-sysupdate` update/verification flow.
+
+**Out of scope:** vulnerabilities in upstream components such as
+freedesktop-sdk, GNOME build metadata, systemd, or k3s itself. Report those to
+the respective upstream project; report to this repository only when the issue
+is introduced by our integration, build, signing, or packaging of the
+component.


### PR DESCRIPTION
Closes #13

## Summary

Adds `SECURITY.md` at the repo root with a vulnerability disclosure policy, and links it from `README.md`.

## What the policy covers

- **Reporting:** GitHub Private Vulnerability Reporting (`/security/advisories/new`) as the primary channel — matching `projectbluefin/bluefin`'s existing policy. The org-wide contact `bluefin@projectbluefin.io` (published in `projectbluefin/dakota`'s SECURITY.md) is listed as a secondary channel. No new contact addresses, PGP keys, or emails were invented.
- **Supported versions:** only the latest GitHub Release is supported — versioning is FSDK-derived (`just version`/`just tags`) and `systemd-sysupdate` pulls exclusively from `releases/latest/download/` (confirmed in `files/os/sysupdate.d/*.transfer`). No LTS branches exist to promise.
- **Response timeline:** conservative coordinated-disclosure wording (acknowledge within a few business days, assessment target 7 days), consistent with the sibling repos' policies.
- **Artifact verification:** verified against the source — `.github/workflows/build.yml` creates one combined `dist/release/SHA256SUMS` plus detached armored `SHA256SUMS.gpg`; the documented `gpg --verify` procedure uses the keyring actually shipped at `files/os/sysupdate-keys/import-pubring.pgp` (key "Bluefin Server Release Signing"). Trust-model details are linked to `docs/skills/systemd-sysupdate-verification.md` rather than duplicated.
- **Out of scope:** upstream freedesktop-sdk / GNOME / systemd / k3s vulnerabilities go upstream unless introduced by our integration.

## Human confirmation needed

- **Private Vulnerability Reporting** could not be confirmed as enabled via the API (field not visible without admin). The sibling `projectbluefin/bluefin` repo already points at its own advisories URL, so this follows org convention — but a maintainer should confirm PVR is enabled on this repo (Settings → Security → Private vulnerability reporting).
- The response timeline wording is a policy commitment a human should ratify before merge.

## Verification

- `python3 .github/scripts/docs-checks.py` passes locally (the "Docs checks" CI workflow lints front-matter, budgets, stale markers, and internal links).

Per the issue workflow, this PR is left open for human review — security policy is a human-approval matter.