### PR TITLE
ci: scope build workflow token to least privilege

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,25 @@ concurrency:
   group: build-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege by default: this workflow executes PR-controlled build code
+# (the Justfile and build scripts come from the PR head), so the workflow-wide
+# token is read-only. contents: write is granted per job only where genuinely
+# required (see track-refs and release below).
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  build-and-release:
+  # Resolves BuildStream junction refs and pushes them back to the PR branch.
+  # This runs PR-controlled code (`just bst source track`) with a write token,
+  # so it keeps the pre-existing renovate/* branch gate. The push updates the
+  # PR branch tip; the build job below runs afterwards and checks out that
+  # updated tip.
+  track-refs:
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/')
     runs-on: ubuntu-24.04
-    timeout-minutes: 180
+    timeout-minutes: 60
+    permissions:
+      contents: write # pushes resolved refs back to the renovate/* PR branch
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -30,7 +42,6 @@ jobs:
           tool: just
 
       - name: Track and Resolve BuildStream Refs
-        if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'renovate/')
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: |
@@ -44,6 +55,29 @@ jobs:
             git commit -m "chore: resolve BuildStream junction refs to git-describe format" -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
             git push origin "HEAD:${HEAD_REF}"
           fi
+
+  build:
+    # Read-only token (workflow default): on pull_request this job checks out
+    # and executes PR-controlled code, so it must never hold a write token.
+    needs: track-refs
+    # track-refs is skipped for non-renovate PRs and pushes; only a failed or
+    # cancelled track job should stop the build.
+    if: ${{ !failure() && !cancelled() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+
+      - name: Set up just
+        uses: taiki-e/install-action@c7eb1735f09259a5035e8e5d44b1406b1cddc0fb # v2
+        with:
+          tool: just
 
       - name: Validate Element Graph
         run: just validate
@@ -98,13 +132,45 @@ jobs:
           echo "$SYSUPDATE_SIGNING_KEY" | gpg --batch --import
           gpg --batch --yes --detach-sign --armor -o dist/release/SHA256SUMS.gpg dist/release/SHA256SUMS
 
-      - name: Upload assets to GitHub Release
+      - name: Resolve release version
         if: github.ref == 'refs/heads/main'
+        id: version
+        run: echo "version=$(just version)" >> "$GITHUB_OUTPUT"
+
+      # Hand the signed assets to the release job below; the build job itself
+      # stays read-only, so it cannot publish the release.
+      - name: Upload release assets artifact
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-assets
+          path: dist/release/
+          if-no-files-found: error
+          retention-days: 1
+
+  # Publishes the signed assets to the GitHub Release. Only runs on
+  # pushes/dispatches to main, where the code is already reviewed, and is the
+  # only job besides track-refs that holds contents: write.
+  release:
+    if: github.ref == 'refs/heads/main'
+    needs: build
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    permissions:
+      contents: write # creates the GitHub Release and uploads its assets
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: release-assets
+          path: dist/release
+
+      - name: Upload assets to GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          V=$(just version)
+          V="${{ needs.build.outputs.version }}"
           TAG="installer-v${V}"
           echo "Uploading release assets for tag: ${TAG}"
           gh release create "${TAG}" --title "Bluefin Server v${V}" --notes "Automated release triggered by Renovate dependency update on main" --prerelease=false || true

--- a/docs/skills/ci-tooling.md
+++ b/docs/skills/ci-tooling.md
@@ -50,17 +50,25 @@ before adding an action.
 
 ### Workflow permissions
 
-The release job in `.github/workflows/build.yml` uses:
+`.github/workflows/build.yml` defaults to a read-only token:
 
 ```yaml
 permissions:
-  contents: write
+  contents: read
 ```
 
-That single permission is sufficient for the workflow to resolve and push
-BuildStream refs, create GitHub Releases, and upload release assets. If a new
-job needs additional permissions, keep them as narrow as possible and document
-why.
+The workflow checks out and executes PR-controlled code (the `Justfile` and
+build scripts come from the PR head), so no job that runs on `pull_request`
+may hold a write token. `contents: write` is granted per job only to:
+
+- `track-refs` — pushes resolved BuildStream refs back to the PR branch; gated
+  to `renovate/*` PRs.
+- `release` — creates the GitHub Release and uploads assets; gated to
+  `refs/heads/main`.
+
+The `build` job (validation, compile, signing) runs with the read-only default
+on every event. If a new job needs additional permissions, keep them as narrow
+as possible and document why.
 
 ### `sudo` scope
 
@@ -86,7 +94,9 @@ sudo_cmd := if `podman info >/dev/null 2>&1 && echo 1 || echo 0` == "1" { "" } e
 
 | Job | Workflow | Trigger | Purpose |
 |-----|----------|---------|---------|
-| `build-and-release` | `build.yml` | `pull_request`, `push/main`, `workflow_dispatch` | Resolves the element graph, runs the full BuildStream compile, and uploads DDI/installer/sysext assets to GitHub Releases on push to `main`. |
+| `track-refs` | `build.yml` | `pull_request` (`renovate/*` only) | Resolves BuildStream junction refs and pushes them back to the PR branch. Sole `contents: write` grant on `pull_request`. |
+| `build` | `build.yml` | `pull_request`, `push/main`, `workflow_dispatch` | Resolves the element graph, runs the full BuildStream compile, and signs the release manifest on pushes to `main`. Read-only token. |
+| `release` | `build.yml` | `push/main`, `workflow_dispatch` | Downloads the signed assets handed off by `build` and publishes them to the GitHub Release. `contents: write`. |
 
 GitHub Actions runs the **complete BuildStream compilation pipeline** using `/mnt`
 SSD storage on the runner for podman and BuildStream caches. Release assets are


### PR DESCRIPTION
Closes #15

## Problem

`build.yml` triggered on `pull_request` with a top-level `permissions: contents: write`, then checked out the PR head and executed PR-controlled build code (`just validate`, `just build-ddi`, `just build-installer`, `just build-sysext` — the `Justfile` and build logic come from the PR). For same-repo branch PRs the `GITHUB_TOKEN` stayed write-capable, so any same-repo PR could run arbitrary code with write access to the repo (push branches, modify releases, rewrite this workflow).

## Permission model

| Job | Before | After | Why |
|---|---|---|---|
| workflow default | `contents: write` | `contents: read` | No job may exceed what it needs. |
| `track-refs` (new) | — (was a step in the single job) | `contents: write` | Only step that writes on `pull_request`: `git push origin HEAD:${HEAD_REF}` of resolved BuildStream refs. Gate `startsWith(github.head_ref, 'renovate/')` is unchanged. |
| `build` (was `build-and-release`) | `contents: write` | read-only (inherits default) | Executes PR-controlled code; needs nothing beyond checkout. Signing uses the GPG secret, not the token. |
| `release` (new) | — (was a step in the single job) | `contents: write` | `gh release create`/`gh release upload` genuinely require it. Still gated to `refs/heads/main` (pushes and dispatches on already-reviewed code). |

## Design notes

- GitHub Actions does not support expressions in `permissions`, so per-event scoping within one job is impossible; the write consumers moved to dedicated, statically-scoped jobs.
- **Ref tracking still reaches the build:** the `track-refs` job pushes the resolved refs to the PR branch (a `GITHUB_TOKEN` push does not trigger a new run, as before); `build` declares `needs: track-refs` and checks out `pull_request.head.ref`, i.e. the updated branch tip. `if: ${{ !failure() && !cancelled() }}` keeps `build` running when `track-refs` is skipped (non-renovate PRs, pushes, dispatches) while still blocking it if tracking fails — same failure semantics as today.
- **Release handoff:** on `main` pushes, `build` signs `dist/release/` exactly as before, then publishes it as a short-lived (`retention-days: 1`) artifact `release-assets`; `release` downloads it and runs the unchanged `gh release create`/`gh release upload` commands with the same tag naming (`installer-v$(just version)`, passed via a job output). Signing logic, GPG steps, and tag naming are untouched.
- No action version bumps (avoids conflict with #16). The two new pins (`actions/upload-artifact@043fb46d… # v7.0.1`, `actions/download-artifact@3e5f45b… # v8`) are the SHAs already used in `projectbluefin/common` and `projectbluefin/dakota`, verified against upstream tags.
- `docs/skills/ci-tooling.md` updated to describe the three-job model.

## Validation

- `actionlint` clean on both workflows.
- `python .github/scripts/docs-checks.py` passes.
- `just validate` passes locally.
- YAML structure verified (job graph, permissions, outputs).

## Reviewer checklist (security-sensitive)

- The `pull_request` CI on this PR exercises the new read-only build path end to end; the `main`-only `release` job can only be fully exercised after merge. Its steps are a byte-for-byte move of the previous release commands plus artifact download.
- First renovate PR after merge will exercise the `track-refs` split; watch that `build` checks out the pushed, ref-resolved tip.
