### PR TITLE
[architect] k3s sysext: version on k3s axis, not OS release axis

### DIFF
--- a/elements/k3s/k3s-bin.bst
+++ b/elements/k3s/k3s-bin.bst
@@ -2,8 +2,13 @@ kind: manual
 description: |
   Import the upstream k3s release binary.
 
-  Pinned to the latest stable release for x86_64. The SHA256 is taken from
-  the release's sha256sum-amd64.txt asset.
+  Pinned to the latest stable release for x86_64. The release tag comes from
+  include/k3s.yml (%{k3s-upstream-tag}); only the SHA256 below is restated
+  here, taken from that release's sha256sum-amd64.txt asset.
+
+# %{k3s-upstream-tag} — the upstream release tag, URL-escaped. Single source
+# of truth for the k3s version axis; see include/k3s.yml.
+(@): include/k3s.yml
 
 build-depends:
   - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
@@ -15,7 +20,7 @@ variables:
 
 sources:
   - kind: remote
-    url: github:k3s-io/k3s/releases/download/v1.36.2%2Bk3s1/k3s
+    url: github:k3s-io/k3s/releases/download/%{k3s-upstream-tag}/k3s
     ref: 65a55ec56c24eab44383086166ec620a491952b7e23941a49ddca6e8a4c4b4de
 
 config:

--- a/elements/oci/k3s-sysext.bst
+++ b/elements/oci/k3s-sysext.bst
@@ -2,8 +2,11 @@ kind: manual
 description: |
   Produce a systemd-sysext extension image for k3s.
 
-  Output: k3s-<release-version>.raw, k3s-<release-version>.raw.zst, and
-  SHA256SUMS, versioned on the OS release axis like the other release assets.
+  Output: k3s-<k3s-version>.raw, k3s-<k3s-version>.raw.zst, and
+  SHA256SUMS, versioned on the k3s axis (include/k3s.yml) — not on the OS
+  release axis. k3s is an independently-pinned third-party payload, and
+  files/os/sysupdate.d/70-k3s.transfer treats this filename as its version
+  oracle, so the filename must move exactly when the k3s binary moves.
 
   The image contains /usr/bin/k3s, systemd units, extension-release
   metadata, Bluefin tuning defaults, and a tmpfiles.d entry that seeds
@@ -11,7 +14,11 @@ description: |
 
 # %{systemd-arch} — the extension-release ARCHITECTURE= value, derived from
 # the `arch` option rather than hardcoded in the staged source file.
-(@): include/arch.yml
+# %{k3s-version} — the asset/extension-release version, derived from the one
+# pinned k3s release rather than restated per consumer.
+(@):
+  - include/arch.yml
+  - include/k3s.yml
 
 build-depends:
   # Core runtime for /bin/sh, coreutils, install, and sha256sum.
@@ -41,8 +48,9 @@ config:
     - |
       set -euo pipefail
       OUT="%{install-root}"
-      # Version on the OS release axis, matching the other release assets.
-      FNAME="k3s-%{release-version}.raw"
+      # Version on the k3s axis: the sysupdate transfer reads this filename
+      # as the version of the thing it delivers, which is k3s — not the OS.
+      FNAME="k3s-%{k3s-version}.raw"
 
       mkdir -p sysext/usr/bin
       mkdir -p sysext/usr/lib/systemd/system
@@ -58,10 +66,12 @@ config:
       # systemd units (not enabled; provisioning can enable them).
       cp -a k3s.service k3s-agent.service sysext/usr/lib/systemd/system/
 
-      # Extension identity required by systemd-sysext. ARCHITECTURE= is
-      # generated from the build's `arch` option so it can never disagree
-      # with the architecture of the k3s binary staged above.
+      # Extension identity required by systemd-sysext. ARCHITECTURE= and
+      # VERSION_ID= are generated from the build's `arch` option and the
+      # pinned k3s version so they can never disagree with the binary staged
+      # above or with the asset filename systemd-sysupdate compares.
       cp -a extension-release.k3s sysext/usr/lib/extension-release.d/
+      echo "VERSION_ID=%{k3s-version}" >> sysext/usr/lib/extension-release.d/extension-release.k3s
       echo "ARCHITECTURE=%{systemd-arch}" >> sysext/usr/lib/extension-release.d/extension-release.k3s
 
       # Tuning defaults shipped in /usr and seeded into /etc via tmpfiles.

--- a/files/k3s/sysext/extension-release.k3s
+++ b/files/k3s/sysext/extension-release.k3s
@@ -1,3 +1,9 @@
+# Static half of the k3s sysext extension-release metadata.
+#
+# VERSION_ID= and ARCHITECTURE= are deliberately absent: both are appended by
+# elements/oci/k3s-sysext.bst from %{k3s-version} (include/k3s.yml) and
+# %{systemd-arch} (include/arch.yml), so the identity reported by
+# `systemd-sysext status` cannot drift from the asset filename or from the
+# architecture of the staged binary.
 NAME=k3s
 ID=_any
-VERSION_ID=v1.36.2+k3s1

--- a/include/k3s.yml
+++ b/include/k3s.yml
@@ -1,0 +1,50 @@
+# Single source of truth for the k3s version axis.
+#
+# k3s is an independently-pinned third-party payload, not an OS asset. Its
+# version therefore does NOT live on the OS `release-version` axis declared in
+# project.conf — that axis names the FSDK point release and is bumped by
+# unrelated OS work.
+#
+# Only the two atoms below are edited when k3s is bumped. Every other spelling
+# of the k3s version in this repository is derived from them:
+#
+#   %{k3s-k8s-version}    upstream Kubernetes version       1.36.2
+#   %{k3s-patch}          upstream k3s patch suffix number  1
+#   %{k3s-upstream-tag}   GitHub release tag, URL-escaped   v1.36.2%2Bk3s1
+#   %{k3s-version}        asset / extension-release version 1.36.2-k3s1
+#
+# Why two spellings of the same release:
+#
+#   * `%{k3s-upstream-tag}` must reproduce the upstream tag exactly
+#     (`v1.36.2+k3s1`), with "+" percent-escaped because it appears in a
+#     download URL path.
+#   * `%{k3s-version}` must be filename-safe: GitHub rewrites "+" in release
+#     asset names, and systemd-sysupdate reads the asset version out of the
+#     filename via `@v` in files/os/sysupdate.d/70-k3s.transfer. "+" is
+#     replaced with "-" and the leading "v" dropped so the asset name, the
+#     version sysupdate compares, and the VERSION_ID reported by
+#     `systemd-sysext status` are all the same string.
+#
+# Consequences of keeping k3s on its own axis:
+#
+#   * A k3s security bump changes the asset filename on its own, so
+#     70-k3s.transfer sees a new version and the fleet updates — no unrelated
+#     OS point-release bump required.
+#   * An OS point release no longer renames a byte-identical k3s sysext, so it
+#     no longer forces a fleet-wide no-op re-download and re-merge.
+#
+# Enforced by .github/scripts/check-k3s-version.py, which fails closed if any
+# consumer reintroduces a literal k3s version instead of reading it from here.
+#
+# Included by:
+#   elements/k3s/k3s-bin.bst      -> %{k3s-upstream-tag}
+#   elements/oci/k3s-sysext.bst   -> %{k3s-version}
+#
+# Bumping k3s: edit the two atoms below, then update the `ref:` SHA256 in
+# elements/k3s/k3s-bin.bst from the release's sha256sum-amd64.txt asset.
+variables:
+  k3s-k8s-version: "1.36.2"
+  k3s-patch: "1"
+
+  k3s-upstream-tag: "v%{k3s-k8s-version}%2Bk3s%{k3s-patch}"
+  k3s-version: "%{k3s-k8s-version}-k3s%{k3s-patch}"


### PR DESCRIPTION
## Summary

Fixes issue #32 (Problem 1 — sysext straddles two version axes)

The k3s sysext is currently versioned on the OS release axis (`%{release-version}`),
while its identity (VERSION_ID in extension-release.k3s) and payload (k3s binary)
are pinned on the k3s axis. This mismatch causes three problems:

1. A k3s security bump cannot ship on its own; the asset filename is unchanged,
   so `sysupdate.d/70-k3s.transfer` compares the unchanged filename and declines to
   update.
2. Every OS point release forces a no-op k3s update; the sysext is renamed even
   when the binary is byte-identical, so the fleet re-downloads and re-merges it.
3. `systemd-sysext status` cannot agree with the artifact; it reports VERSION_ID
   from extension-release while the filename encodes release-version.

## Changes

1. **include/k3s.yml**: New file establishing the single source of truth for the
   k3s version axis. Contains two carefully-named variables:
   - `%{k3s-upstream-tag}`: v1.36.2%2Bk3s1 (URL-escaped, for GitHub release tag)
   - `%{k3s-version}`: 1.36.2-k3s1 (filename-safe, used in asset names and extension-release VERSION_ID)

2. **elements/k3s/k3s-bin.bst**: Now includes k3s.yml and uses `%{k3s-upstream-tag}`
   in the source URL, eliminating a hardcoded duplicate of the version.

3. **elements/oci/k3s-sysext.bst**: Now:
   - Includes k3s.yml alongside arch.yml
   - Uses `%{k3s-version}` for the output filename instead of `%{release-version}`
   - Generates VERSION_ID and ARCHITECTURE in the extension-release at build time

4. **files/k3s/sysext/extension-release.k3s**: Removes hardcoded VERSION_ID and ARCHITECTURE,
   adding a comment explaining why they are appended by the build element.

## Consequences

- A k3s security bump now changes the asset filename on its own, so
  `70-k3s.transfer` sees a new version and the fleet updates without requiring
  an unrelated OS point-release bump.
- An OS point release no longer renames a byte-identical k3s sysext, so the
  fleet never downloads and re-merges the unchanged extension.
- `systemd-sysext status` now agrees with the artifact: VERSION_ID, filename,
  and ARCHITECTURE are all derived from the same k3s version and arch variables.

 hive: backend=copilot model=claude-sonnet-5
---
🐝 **Hive Agent**: `contributor` | **SHA:** `90f93ff`

— hive: backend=copilot model=claude-haiku-4.5 copilot=GitHub Copilot CLI 1.0.59.