### PR TITLE
fix(fsdk): disable tests in glib-stage1 bootstrap

### DIFF
--- a/patches/freedesktop-sdk/0002-glib-stage1-disable-tests.patch
+++ b/patches/freedesktop-sdk/0002-glib-stage1-disable-tests.patch
@@ -1,0 +1,12 @@
+diff --git a/elements/components/_private/glib-stage1.bst b/elements/components/_private/glib-stage1.bst
+index 903ad40..abc3b6e 100644
+--- a/elements/components/_private/glib-stage1.bst
++++ b/elements/components/_private/glib-stage1.bst
+@@ -23,6 +23,7 @@ variables:
+   meson-local: >-
+     -Dauto_features=disabled
+     -Dglib_debug=disabled
++    -Dtests=false
+ 
+ public:
+   bst:


### PR DESCRIPTION
Closes #50.

During bootstrap builds from source, glib-stage1 failed with exit code 127
when ninja attempted to execute uninstalled glib-compile-resources to build
gio/tests/test5.gresource before libgio was installed.
Disabling tests in stage1 bypasses test compilation and avoids the linker failure.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
