### PR TITLE
fix(fsdk): resolve libgirepository SONAME symlinks in gobject-introspection-base

### DIFF
--- a/patches/freedesktop-sdk/0003-gobject-introspection-base-library-symlinks.patch
+++ b/patches/freedesktop-sdk/0003-gobject-introspection-base-library-symlinks.patch
@@ -1,0 +1,16 @@
+diff --git a/elements/components/_private/gobject-introspection-base.bst b/elements/components/_private/gobject-introspection-base.bst
+index 79b32b5..61eecdf 100644
+--- a/elements/components/_private/gobject-introspection-base.bst
++++ b/elements/components/_private/gobject-introspection-base.bst
+@@ -23,6 +23,11 @@ variables:
+     -Dcairo=disabled
+     -Dgtk_doc=true
+     -Ddoctool=enabled
++  meson-build: |
++    mkdir -p %{build-dir}/girepository
++    ln -sf libgirepository-1.0.so.1.0.0 %{build-dir}/girepository/libgirepository-1.0.so.1
++    ln -sf libgirepository-1.0.so.1 %{build-dir}/girepository/libgirepository-1.0.so
++    LD_LIBRARY_PATH="$(pwd)/%{build-dir}/girepository:${LD_LIBRARY_PATH:-}" ninja -v -j ${JOBS} -C %{build-dir}
+ 
+ public:
+   bst:


### PR DESCRIPTION
Resolves #53 by creating the SONAME symlinks and exporting LD_LIBRARY_PATH in gobject-introspection-base before invoking ninja.