### PR TITLE
fix(build): add SONAME symlinks and LD_LIBRARY_PATH for gdk-pixbuf

### DIFF
--- a/patches/freedesktop-sdk/0004-gdk-pixbuf-library-symlinks.patch
+++ b/patches/freedesktop-sdk/0004-gdk-pixbuf-library-symlinks.patch
@@ -1,0 +1,16 @@
+diff --git a/elements/components/gdk-pixbuf.bst b/elements/components/gdk-pixbuf.bst
+index 60f8f89..878c7c9 100644
+--- a/elements/components/gdk-pixbuf.bst
++++ b/elements/components/gdk-pixbuf.bst
+@@ -24,6 +24,11 @@ variables:
+     -Djpeg=disabled
+     -Dpng=disabled
+     -Dtiff=disabled
++  meson-build: |
++    mkdir -p %{build-dir}/gdk-pixbuf
++    ln -sf libgdk_pixbuf-2.0.so.0.4400.7 %{build-dir}/gdk-pixbuf/libgdk_pixbuf-2.0.so.0
++    ln -sf libgdk_pixbuf-2.0.so.0 %{build-dir}/gdk-pixbuf/libgdk_pixbuf-2.0.so
++    LD_LIBRARY_PATH="$(pwd)/%{build-dir}/gdk-pixbuf:${LD_LIBRARY_PATH:-}" ninja -v -j ${JOBS} -C %{build-dir}
+ 
+ public:
+   bst:


### PR DESCRIPTION
Closes #55

### Description
In remote execution environments (BuildBarn), `components/gdk-pixbuf.bst` fails in `ninja` when running uninstalled `gdk-pixbuf-print-mime-types` because `libgdk_pixbuf-2.0.so.0` SONAME symlink is missing in the builddir.

This patch adds the symlinks and exports `LD_LIBRARY_PATH` in `meson-build`.