### PR TITLE
fix(build): prepare alpha release validation and sysext cleanup

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,8 @@
+# Bluefin Server — Copilot Instructions
+
+Read [`AGENTS.md`](../AGENTS.md) for the full repo contract — build commands,
+PR rules, mandatory gates, and boundaries.
+
+## Skill routing
+
+Use [`docs/skills/index.md`](../docs/skills/index.md) to route to the skill for your task.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,8 @@ Bluefin Server is an FSDK-based, image-based Linux server OS. It produces:
 
 1. Read this file.
 2. Load [`docs/skills/index.md`](docs/skills/index.md) to route to the skill for your task.
-3. Never guess label names, workflow secrets, or infrastructure hostnames — check the relevant skill.
+3. Cross-repo factory directives: follow [`projectbluefin/common:docs/factory/agentic-model.md`](https://github.com/projectbluefin/common/blob/main/docs/factory/agentic-model.md) — query `projectbluefin` MCP (`search_knowledge`) before investigating or implementing.
+4. Never guess label names, workflow secrets, or infrastructure hostnames — check the relevant skill.
 
 ## Hard rules
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,21 @@
+# Bluefin Server
+
+An immutable, Freedesktop-SDK-based Linux server operating system providing native systemd update and extension mechanisms.
+
+## Language
+
+**OS DDI**:
+The immutable raw disk image payload containing the base operating system root filesystem.
+_Avoid_: base image, OS rootfs, root tarball
+
+**Installer**:
+A bootable GPT raw disk image executing systemd-repart to partition and install Bluefin Server onto target media.
+_Avoid_: live ISO, installation media, setup script
+
+**Sysext**:
+A systemd-sysext extension raw image merged into `/usr` to deliver decoupled server runtimes such as k0s.
+_Avoid_: addon, plugin, package, sidecar
+
+**Transfer**:
+A systemd-sysupdate definition mapping a remote release asset to a local target file or partition.
+_Avoid_: update manifest, download job, sync rule

--- a/Justfile
+++ b/Justfile
@@ -22,6 +22,8 @@ export fsdk_ref := `grep -E '^\s*ref:' elements/freedesktop-sdk.bst | head -1 | 
 bst *ARGS:
     #!/usr/bin/env bash
     set -euo pipefail
+    export CONTAINERS_CONF="${CONTAINERS_CONF:-/dev/null}"
+    export CONTAINERS_CONF_OVERRIDE="${CONTAINERS_CONF_OVERRIDE:-/dev/null}"
     mkdir -p "${HOME}/.cache/buildstream"
     # shellcheck disable=SC2086
     {{sudo_cmd}} podman run --rm \
@@ -150,7 +152,6 @@ export-sysext: build-sysext
     cp dist/sysext-checkout/k0s-*.raw.zst dist/sysext/
     cp dist/sysext-checkout/SHA256SUMS dist/sysext/
     rm -rf dist/sysext-checkout
-    for f in dist/sysext/k0s-*.raw.zst; do [ -f "$f" ] && ln -sf "$(basename "$f")" "dist/sysext/k3s-${f#*dist/sysext/k0s-}"; done
     @echo "==> wrote k0s sysext:" && ls -lh dist/sysext/
 
 # Write the raw GPT installer image to a physical USB drive.

--- a/Justfile
+++ b/Justfile
@@ -152,6 +152,7 @@ export-sysext: build-sysext
     cp dist/sysext-checkout/k0s-*.raw.zst dist/sysext/
     cp dist/sysext-checkout/SHA256SUMS dist/sysext/
     rm -rf dist/sysext-checkout
+    for f in dist/sysext/k0s-*.raw.zst; do [ -f "$f" ] && ln -sf "$(basename "$f")" "dist/sysext/k3s-${f#*dist/sysext/k0s-}"; done
     @echo "==> wrote k0s sysext:" && ls -lh dist/sysext/
 
 # Write the raw GPT installer image to a physical USB drive.

--- a/elements/bluefin-server/linux-firmware-split.bst
+++ b/elements/bluefin-server/linux-firmware-split.bst
@@ -5,6 +5,8 @@ build-depends:
   - freedesktop-sdk.bst:components/linux-firmware.bst
 
 config:
+  integrate: False
+
   # Exclude debug symbols, development files, and locales from composed output
   exclude:
     - debug

--- a/elements/bluefin-server/os-rootfs.bst
+++ b/elements/bluefin-server/os-rootfs.bst
@@ -9,3 +9,4 @@ config:
     - debug
     - devel
     - doc
+  integrate: False

--- a/elements/bluefin-server/os-stack.bst
+++ b/elements/bluefin-server/os-stack.bst
@@ -2,8 +2,9 @@ kind: stack
 description: Stack containing all elements required to build a pure DDI Bluefin Server rootfs.
 
 depends:
-  # Base runtime & core libraries
+  # Base runtime & core libraries (minimal non-GNU base + uutils modern userspace)
   - freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+  - bluefin-server/uutils-coreutils.bst
   - freedesktop-sdk.bst:components/ca-certificates.bst
   - freedesktop-sdk.bst:components/tzdata.bst
   - freedesktop-sdk.bst:integration/extra-fs.bst

--- a/elements/bluefin-server/uutils-coreutils.bst
+++ b/elements/bluefin-server/uutils-coreutils.bst
@@ -1,4 +1,4 @@
-kind: make
+kind: manual
 
 config:
   build-commands:
@@ -124,6 +124,7 @@ public:
     - /usr/bin/yes
 
 build-depends:
+- base/base-stack.bst
 - freedesktop-sdk.bst:components/rust.bst
 - freedesktop-sdk.bst:public-stacks/buildsystem-make.bst
 

--- a/elements/bluefin-server/uutils-coreutils.bst
+++ b/elements/bluefin-server/uutils-coreutils.bst
@@ -1,0 +1,1732 @@
+kind: make
+
+config:
+  build-commands:
+  - cargo build --release --features feat_os_unix --no-default-features
+
+  install-commands:
+  - install -Dm755 target/release/coreutils "%{install-root}/usr/bin/uutils-coreutils"
+  - |
+    for prog in $(target/release/coreutils --list); do
+      ln -sr "%{install-root}/usr/bin/uutils-coreutils" "%{install-root}/usr/bin/uutils-${prog}"
+      ln -sr "%{install-root}/usr/bin/uutils-coreutils" "%{install-root}/usr/bin/${prog}"
+    done
+
+public:
+  bst:
+    overlap-whitelist:
+    - /usr/bin/[
+    - /usr/bin/arch
+    - /usr/bin/b2sum
+    - /usr/bin/base32
+    - /usr/bin/base64
+    - /usr/bin/basename
+    - /usr/bin/basenc
+    - /usr/bin/cat
+    - /usr/bin/chgrp
+    - /usr/bin/chmod
+    - /usr/bin/chown
+    - /usr/bin/chroot
+    - /usr/bin/cksum
+    - /usr/bin/comm
+    - /usr/bin/cp
+    - /usr/bin/csplit
+    - /usr/bin/cut
+    - /usr/bin/date
+    - /usr/bin/dd
+    - /usr/bin/df
+    - /usr/bin/dir
+    - /usr/bin/dircolors
+    - /usr/bin/dirname
+    - /usr/bin/du
+    - /usr/bin/echo
+    - /usr/bin/env
+    - /usr/bin/expand
+    - /usr/bin/expr
+    - /usr/bin/factor
+    - /usr/bin/false
+    - /usr/bin/fmt
+    - /usr/bin/fold
+    - /usr/bin/groups
+    - /usr/bin/head
+    - /usr/bin/hostid
+    - /usr/bin/hostname
+    - /usr/bin/id
+    - /usr/bin/install
+    - /usr/bin/join
+    - /usr/bin/kill
+    - /usr/bin/link
+    - /usr/bin/ln
+    - /usr/bin/logname
+    - /usr/bin/ls
+    - /usr/bin/md5sum
+    - /usr/bin/mkdir
+    - /usr/bin/mkfifo
+    - /usr/bin/mknod
+    - /usr/bin/mktemp
+    - /usr/bin/more
+    - /usr/bin/mv
+    - /usr/bin/nice
+    - /usr/bin/nl
+    - /usr/bin/nohup
+    - /usr/bin/nproc
+    - /usr/bin/numfmt
+    - /usr/bin/od
+    - /usr/bin/paste
+    - /usr/bin/pathchk
+    - /usr/bin/pinky
+    - /usr/bin/pr
+    - /usr/bin/printenv
+    - /usr/bin/printf
+    - /usr/bin/ptx
+    - /usr/bin/pwd
+    - /usr/bin/readlink
+    - /usr/bin/realpath
+    - /usr/bin/rm
+    - /usr/bin/rmdir
+    - /usr/bin/seq
+    - /usr/bin/sha1sum
+    - /usr/bin/sha224sum
+    - /usr/bin/sha256sum
+    - /usr/bin/sha384sum
+    - /usr/bin/sha512sum
+    - /usr/bin/shred
+    - /usr/bin/shuf
+    - /usr/bin/sleep
+    - /usr/bin/sort
+    - /usr/bin/split
+    - /usr/bin/stat
+    - /usr/bin/stdbuf
+    - /usr/bin/stty
+    - /usr/bin/sum
+    - /usr/bin/sync
+    - /usr/bin/tac
+    - /usr/bin/tail
+    - /usr/bin/tee
+    - /usr/bin/test
+    - /usr/bin/timeout
+    - /usr/bin/touch
+    - /usr/bin/tr
+    - /usr/bin/true
+    - /usr/bin/truncate
+    - /usr/bin/tsort
+    - /usr/bin/tty
+    - /usr/bin/uname
+    - /usr/bin/unexpand
+    - /usr/bin/uniq
+    - /usr/bin/unlink
+    - /usr/bin/uptime
+    - /usr/bin/users
+    - /usr/bin/vdir
+    - /usr/bin/wc
+    - /usr/bin/who
+    - /usr/bin/whoami
+    - /usr/bin/yes
+
+build-depends:
+- freedesktop-sdk.bst:components/rust.bst
+- freedesktop-sdk.bst:public-stacks/buildsystem-make.bst
+
+depends:
+- freedesktop-sdk.bst:public-stacks/runtime-minimal.bst
+
+sources:
+- kind: git_repo
+  url: github:uutils/coreutils.git
+  track: '[0-9]*.[0-9]*.[0-9]*'
+  ref: 0.11.0-0-gbf65901e1ed82963436844c2cf8e796ba9158c65 # 0.8.0
+- kind: cargo2
+  url: crates:crates
+  ref:
+  - kind: registry
+    name: adler2
+    version: 2.0.1
+    sha: 320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa
+  - kind: registry
+    name: aho-corasick
+    version: 1.1.5
+    sha: c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba
+  - kind: registry
+    name: allocator-api2
+    version: 0.2.21
+    sha: 683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923
+  - kind: registry
+    name: android_system_properties
+    version: 0.1.6
+    sha: ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc
+  - kind: registry
+    name: ansi-width
+    version: 0.1.0
+    sha: 219e3ce6f2611d83b51ec2098a12702112c29e57203a6b0a0929b2cddb486608
+  - kind: registry
+    name: anstream
+    version: 1.0.0
+    sha: 824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d
+  - kind: registry
+    name: anstyle
+    version: 1.0.14
+    sha: 940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000
+  - kind: registry
+    name: anstyle-parse
+    version: 1.0.0
+    sha: 52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e
+  - kind: registry
+    name: anstyle-query
+    version: 1.1.5
+    sha: 40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc
+  - kind: registry
+    name: anstyle-wincon
+    version: 3.0.11
+    sha: 291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d
+  - kind: registry
+    name: anyhow
+    version: 1.0.104
+    sha: 330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470
+  - kind: registry
+    name: approx
+    version: 0.5.1
+    sha: cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6
+  - kind: registry
+    name: ariadne
+    version: 0.6.0
+    sha: 8454c8a44ce2cb9cc7e7fae67fc6128465b343b92c6631e94beca3c8d1524ea5
+  - kind: registry
+    name: arrayvec
+    version: 0.7.8
+    sha: d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56
+  - kind: registry
+    name: autocfg
+    version: 1.5.1
+    sha: f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53
+  - kind: registry
+    name: base64-simd
+    version: 0.8.0
+    sha: 339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195
+  - kind: registry
+    name: bigdecimal
+    version: 0.4.10
+    sha: 4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695
+  - kind: registry
+    name: bindgen
+    version: 0.72.1
+    sha: 993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895
+  - kind: registry
+    name: bitflags
+    version: 1.3.2
+    sha: bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a
+  - kind: registry
+    name: bitflags
+    version: 2.13.1
+    sha: b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da
+  - kind: registry
+    name: bitvec
+    version: 1.1.1
+    sha: ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837
+  - kind: registry
+    name: blake2b_simd
+    version: 1.0.5
+    sha: 3560a7b1951efe814fcd721938313adc56753ca39f4b23847d7e9a2402f5dbff
+  - kind: registry
+    name: blake3
+    version: 1.8.7
+    sha: 6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae
+  - kind: registry
+    name: block-buffer
+    version: 0.12.1
+    sha: d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa
+  - kind: registry
+    name: block2
+    version: 0.6.2
+    sha: cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5
+  - kind: registry
+    name: bstr
+    version: 1.13.1
+    sha: 6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f
+  - kind: registry
+    name: bumpalo
+    version: 3.20.3
+    sha: 72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649
+  - kind: registry
+    name: bytecount
+    version: 0.6.9
+    sha: 175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e
+  - kind: registry
+    name: byteorder
+    version: 1.5.0
+    sha: 1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b
+  - kind: registry
+    name: calendrical_calculations
+    version: 0.2.4
+    sha: 5abbd6eeda6885048d357edc66748eea6e0268e3dd11f326fff5bd248d779c26
+  - kind: registry
+    name: cc
+    version: 1.4.3
+    sha: 509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d
+  - kind: registry
+    name: cexpr
+    version: 0.6.0
+    sha: 6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766
+  - kind: registry
+    name: cfg-if
+    version: 1.0.4
+    sha: 9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801
+  - kind: registry
+    name: cfg_aliases
+    version: 0.2.2
+    sha: f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527
+  - kind: registry
+    name: chacha20
+    version: 0.10.1
+    sha: d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81
+  - kind: registry
+    name: chrono
+    version: 0.4.45
+    sha: 1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327
+  - kind: registry
+    name: clang-sys
+    version: 1.9.1
+    sha: 157a8ba7b480713b56f4c09fd13fc3e0a22a5dfab8097ba61cbc5feef950788a
+  - kind: registry
+    name: clap
+    version: 4.6.6
+    sha: 473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca
+  - kind: registry
+    name: clap_builder
+    version: 4.6.6
+    sha: 7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889
+  - kind: registry
+    name: clap_complete
+    version: 4.6.9
+    sha: 3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19
+  - kind: registry
+    name: clap_lex
+    version: 1.1.0
+    sha: c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9
+  - kind: registry
+    name: clap_mangen
+    version: 0.3.3
+    sha: 211d617eaa4b735c96c9e0228fcbdb5120ef623f2b8cb67ffb84c3e02dbc28a4
+  - kind: registry
+    name: codspeed
+    version: 5.0.1
+    sha: 7083f253260bcb4aaa3b4aa4c52973703dabc1a85c2f193997e2689aafa8a919
+  - kind: registry
+    name: codspeed-divan-compat
+    version: 5.0.1
+    sha: bc1065d507e1cbab731a7976db4cef7e47e49b87b4dbc0a925df07d343558420
+  - kind: registry
+    name: codspeed-divan-compat-macros
+    version: 5.0.1
+    sha: 2fd05482a95823ffe421e8a9ba24fa22a6a30d594e2c60455cbb43a41bf2d8fa
+  - kind: registry
+    name: codspeed-divan-compat-walltime
+    version: 5.0.1
+    sha: d2f8eae75b8fa85357020a404899c4280d590c9fd1c47640b3ce53106c62d2ee
+  - kind: registry
+    name: colorchoice
+    version: 1.0.5
+    sha: 1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570
+  - kind: registry
+    name: colored
+    version: 3.1.1
+    sha: faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34
+  - kind: registry
+    name: condtype
+    version: 1.3.0
+    sha: baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af
+  - kind: registry
+    name: console
+    version: 0.16.4
+    sha: 4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c
+  - kind: registry
+    name: const-random
+    version: 0.1.18
+    sha: 87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359
+  - kind: registry
+    name: const-random-macro
+    version: 0.1.16
+    sha: f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e
+  - kind: registry
+    name: constant_time_eq
+    version: 0.4.2
+    sha: 3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b
+  - kind: registry
+    name: core-foundation-sys
+    version: 0.8.7
+    sha: 773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b
+  - kind: registry
+    name: core_maths
+    version: 0.1.1
+    sha: 77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30
+  - kind: registry
+    name: cpufeatures
+    version: 0.3.0
+    sha: 8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201
+  - kind: registry
+    name: crc
+    version: 3.3.0
+    sha: 9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675
+  - kind: registry
+    name: crc-catalog
+    version: 2.5.0
+    sha: 217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853
+  - kind: registry
+    name: crc-fast
+    version: 1.9.0
+    sha: 2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d
+  - kind: registry
+    name: crc32fast
+    version: 1.5.0
+    sha: 9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511
+  - kind: registry
+    name: crossbeam-deque
+    version: 0.8.7
+    sha: 5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb
+  - kind: registry
+    name: crossbeam-epoch
+    version: 0.9.20
+    sha: 2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f
+  - kind: registry
+    name: crossbeam-utils
+    version: 0.8.22
+    sha: 61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17
+  - kind: registry
+    name: crossterm
+    version: 0.29.0
+    sha: d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b
+  - kind: registry
+    name: crossterm_winapi
+    version: 0.9.1
+    sha: acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b
+  - kind: registry
+    name: crunchy
+    version: 0.2.4
+    sha: 460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5
+  - kind: registry
+    name: crypto-common
+    version: 0.1.7
+    sha: 78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a
+  - kind: registry
+    name: crypto-common
+    version: 0.2.2
+    sha: ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453
+  - kind: registry
+    name: ctor
+    version: 1.0.13
+    sha: 914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d
+  - kind: registry
+    name: ctrlc
+    version: 3.5.2
+    sha: e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162
+  - kind: registry
+    name: data-encoding
+    version: 2.11.1
+    sha: 4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06
+  - kind: registry
+    name: data-encoding-macro
+    version: 0.1.21
+    sha: c6a127ecbb3c4632e1525380e04c0c3fcf8dcb44d32a79ea290d8a36906edcd8
+  - kind: registry
+    name: data-encoding-macro-internal
+    version: 0.1.19
+    sha: c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead
+  - kind: registry
+    name: defmt
+    version: 1.1.1
+    sha: e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1
+  - kind: registry
+    name: defmt-macros
+    version: 1.1.1
+    sha: bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8
+  - kind: registry
+    name: defmt-parser
+    version: 1.0.0
+    sha: 10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e
+  - kind: registry
+    name: deranged
+    version: 0.5.8
+    sha: 7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c
+  - kind: registry
+    name: diff
+    version: 0.1.13
+    sha: 56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8
+  - kind: registry
+    name: digest
+    version: 0.10.7
+    sha: 9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292
+  - kind: registry
+    name: digest
+    version: 0.11.3
+    sha: f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2
+  - kind: registry
+    name: dispatch2
+    version: 0.3.1
+    sha: 1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38
+  - kind: registry
+    name: displaydoc
+    version: 0.2.7
+    sha: c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8
+  - kind: registry
+    name: divan-macros
+    version: 0.1.17
+    sha: 8dc51d98e636f5e3b0759a39257458b22619cac7e96d932da6eeb052891bb67c
+  - kind: registry
+    name: dlv-list
+    version: 0.5.2
+    sha: 442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f
+  - kind: registry
+    name: dns-lookup
+    version: 4.0.1
+    sha: 6120e7e5dcd1c90098e349def389e2797377cdbe6b465ad8fdd115c0c99d5cf2
+  - kind: registry
+    name: document-features
+    version: 0.2.12
+    sha: d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61
+  - kind: registry
+    name: dunce
+    version: 1.0.5
+    sha: 92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813
+  - kind: registry
+    name: either
+    version: 1.17.0
+    sha: 9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d
+  - kind: registry
+    name: encode_unicode
+    version: 1.0.0
+    sha: 34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0
+  - kind: registry
+    name: equivalent
+    version: 1.0.2
+    sha: 877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f
+  - kind: registry
+    name: errno
+    version: 0.3.14
+    sha: 39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb
+  - kind: registry
+    name: fastrand
+    version: 2.5.0
+    sha: da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223
+  - kind: registry
+    name: filedescriptor
+    version: 0.8.3
+    sha: e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d
+  - kind: registry
+    name: filetime
+    version: 0.2.29
+    sha: 5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759
+  - kind: registry
+    name: find-msvc-tools
+    version: 0.1.11
+    sha: d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890
+  - kind: registry
+    name: fixed_decimal
+    version: 0.7.2
+    sha: 79c3c892f121fff406e5dd6b28c1b30096b95111c30701a899d4f2b18da6d1bd
+  - kind: registry
+    name: flate2
+    version: 1.1.9
+    sha: 843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c
+  - kind: registry
+    name: fluent
+    version: 0.17.0
+    sha: 8137a6d5a2c50d6b0ebfcb9aaa91a28154e0a70605f112d30cb0cd4a78670477
+  - kind: registry
+    name: fluent-bundle
+    version: 0.16.0
+    sha: 01203cb8918f5711e73891b347816d932046f95f54207710bda99beaeb423bf4
+  - kind: registry
+    name: fluent-langneg
+    version: 0.13.1
+    sha: 7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0
+  - kind: registry
+    name: fluent-syntax
+    version: 0.12.0
+    sha: 54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198
+  - kind: registry
+    name: foldhash
+    version: 0.2.0
+    sha: 77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb
+  - kind: registry
+    name: foreign-types
+    version: 0.3.2
+    sha: f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1
+  - kind: registry
+    name: foreign-types-shared
+    version: 0.1.1
+    sha: 00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b
+  - kind: registry
+    name: fs_extra
+    version: 1.3.0
+    sha: 42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c
+  - kind: registry
+    name: fsevent-sys
+    version: 4.1.0
+    sha: 76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2
+  - kind: registry
+    name: fts-sys
+    version: 0.2.17
+    sha: 9c03259139c9b098dd92241b046fedfeebcd6b000d491c821b24ced28558a9c2
+  - kind: registry
+    name: funty
+    version: 2.0.0
+    sha: e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c
+  - kind: registry
+    name: futures-core
+    version: 0.3.33
+    sha: 2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7
+  - kind: registry
+    name: futures-macro
+    version: 0.3.33
+    sha: 2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b
+  - kind: registry
+    name: futures-task
+    version: 0.3.33
+    sha: b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109
+  - kind: registry
+    name: futures-timer
+    version: 3.0.4
+    sha: af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968
+  - kind: registry
+    name: futures-util
+    version: 0.3.33
+    sha: a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa
+  - kind: registry
+    name: gcd
+    version: 2.3.0
+    sha: 1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a
+  - kind: registry
+    name: generic-array
+    version: 0.14.7
+    sha: 85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a
+  - kind: registry
+    name: getrandom
+    version: 0.2.17
+    sha: ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0
+  - kind: registry
+    name: getrandom
+    version: 0.4.3
+    sha: 300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099
+  - kind: registry
+    name: glob
+    version: 0.3.4
+    sha: e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b
+  - kind: registry
+    name: half
+    version: 2.7.1
+    sha: 6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b
+  - kind: registry
+    name: hashbrown
+    version: 0.14.5
+    sha: e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1
+  - kind: registry
+    name: hashbrown
+    version: 0.16.1
+    sha: 841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100
+  - kind: registry
+    name: hashbrown
+    version: 0.17.1
+    sha: ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a
+  - kind: registry
+    name: hex
+    version: 0.4.3
+    sha: 7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70
+  - kind: registry
+    name: hex-literal
+    version: 1.1.0
+    sha: e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1
+  - kind: registry
+    name: hostname
+    version: 0.4.2
+    sha: 617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd
+  - kind: registry
+    name: hybrid-array
+    version: 0.4.14
+    sha: 707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b
+  - kind: registry
+    name: iana-time-zone
+    version: 0.1.65
+    sha: e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470
+  - kind: registry
+    name: iana-time-zone-haiku
+    version: 0.1.2
+    sha: f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f
+  - kind: registry
+    name: icu_calendar
+    version: 2.3.0
+    sha: 58655df2f728e46e4eee80bddebefacf52ec3e77cdb925014b47c5a5905eb55c
+  - kind: registry
+    name: icu_calendar_data
+    version: 2.3.0
+    sha: dc00caaa3fb3201ff7a18aa458e8c3ab042b9da154cfdf948bdde3936c31c36e
+  - kind: registry
+    name: icu_collator
+    version: 2.3.1
+    sha: 08984ed58ac439ebf3e13d2cf26b0c46a60afcd21721c1d14087c0b240344dda
+  - kind: registry
+    name: icu_collator_data
+    version: 2.3.0
+    sha: f7d7e54efdddeb1208c08dd5d32b53a879ac00d2d3d051b2255fd26821d16368
+  - kind: registry
+    name: icu_collections
+    version: 2.3.0
+    sha: fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513
+  - kind: registry
+    name: icu_datetime
+    version: 2.3.0
+    sha: c44df99c4c5297b05653d1a1629f13bdc9fd4044acfbbaf30b15194a1eed4cd6
+  - kind: registry
+    name: icu_datetime_data
+    version: 2.3.0
+    sha: 8bb5555f6e4b42233f58564351ce16d73e9e6ebfce6bdcf29875d0cfc554d6a8
+  - kind: registry
+    name: icu_decimal
+    version: 2.3.0
+    sha: 9eb8f655bba2d0c0459e43a5b0e6cd3cd388109898fb3d85d048165e8b0abd08
+  - kind: registry
+    name: icu_decimal_data
+    version: 2.3.0
+    sha: e4c887fc7d4c297cf3f9436864af9e3dba7f8be9415a6c2a7f392f3b1636298c
+  - kind: registry
+    name: icu_locale
+    version: 2.3.1
+    sha: 785f595c61ef57169a467eeed7b4b6936a66f6cacbb116a96ee86da983251bf4
+  - kind: registry
+    name: icu_locale_core
+    version: 2.3.0
+    sha: d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb
+  - kind: registry
+    name: icu_locale_data
+    version: 2.3.0
+    sha: d37d91460e362a5cf58907cd7ce871411775ee6294e49a5cc8e6cec16dfa75ea
+  - kind: registry
+    name: icu_locale_fallback
+    version: 2.3.0
+    sha: 251af8e57c9400e3eb58242fe5b8b1152b2a64fdf4cf632f923c38ccee6f2fa9
+  - kind: registry
+    name: icu_locale_fallback_data
+    version: 2.3.0
+    sha: decf2a22ec8fa68f1a0c1129a3f8583f8f8bc24e8b9ccbe98ead99f62a4dc3a8
+  - kind: registry
+    name: icu_normalizer
+    version: 2.3.0
+    sha: 12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f
+  - kind: registry
+    name: icu_normalizer_data
+    version: 2.3.0
+    sha: 1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0
+  - kind: registry
+    name: icu_pattern
+    version: 0.5.0
+    sha: 2b3db611446bd92c246b03e4aa0bafa71ddb194af431ddbb42b9d70e4bfce1a0
+  - kind: registry
+    name: icu_plurals
+    version: 2.3.0
+    sha: e475e6766ef87b1d3c1f97be6363995b0bfaeddbc789671615df598a97ff0593
+  - kind: registry
+    name: icu_plurals_data
+    version: 2.3.0
+    sha: 1251aa39a95e1333888e499b1263e1c196447a28948acf5bdabd82c046f153bf
+  - kind: registry
+    name: icu_properties
+    version: 2.3.0
+    sha: 7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148
+  - kind: registry
+    name: icu_properties_data
+    version: 2.3.0
+    sha: e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa
+  - kind: registry
+    name: icu_provider
+    version: 2.3.1
+    sha: d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73
+  - kind: registry
+    name: icu_time
+    version: 2.3.0
+    sha: af37e1c3b9f3ab564b619fdf4b22de169f6381eb0f7048e3ca454290c438126b
+  - kind: registry
+    name: icu_time_data
+    version: 2.3.0
+    sha: 005ff86fa5851a77fc0a977b72d717f777bd9230415a247219d7898aefb1517a
+  - kind: registry
+    name: indexmap
+    version: 2.14.0
+    sha: d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9
+  - kind: registry
+    name: indicatif
+    version: 0.18.6
+    sha: 9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c
+  - kind: registry
+    name: inotify
+    version: 0.11.4
+    sha: 153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8
+  - kind: registry
+    name: inotify-sys
+    version: 0.1.8
+    sha: c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d
+  - kind: registry
+    name: intl-memoizer
+    version: 0.5.3
+    sha: 310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f
+  - kind: registry
+    name: intl_pluralrules
+    version: 7.0.2
+    sha: 078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972
+  - kind: registry
+    name: is_terminal_polyfill
+    version: 1.70.2
+    sha: a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695
+  - kind: registry
+    name: itertools
+    version: 0.13.0
+    sha: 413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186
+  - kind: registry
+    name: itertools
+    version: 0.14.0
+    sha: 2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285
+  - kind: registry
+    name: itertools
+    version: 0.15.0
+    sha: 8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc
+  - kind: registry
+    name: itoa
+    version: 1.0.18
+    sha: 8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682
+  - kind: registry
+    name: jiff
+    version: 0.2.35
+    sha: 668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc
+  - kind: registry
+    name: jiff-core
+    version: 0.1.0
+    sha: 7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09
+  - kind: registry
+    name: jiff-icu
+    version: 0.2.2
+    sha: 0e67c2beaae8b10a82d849b9aabb698a43a682f32b17bcdc035d5ecadb44d646
+  - kind: registry
+    name: jiff-static
+    version: 0.2.35
+    sha: 3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204
+  - kind: registry
+    name: jiff-tzdb
+    version: 0.1.8
+    sha: 142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e
+  - kind: registry
+    name: jiff-tzdb-platform
+    version: 0.1.3
+    sha: 875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8
+  - kind: registry
+    name: js-sys
+    version: 0.3.103
+    sha: 53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102
+  - kind: registry
+    name: keccak
+    version: 0.2.1
+    sha: ffd9697dc4a9a62e2da93389f34400b77a28f0287711263cabb203b3ccb9c0e4
+  - kind: registry
+    name: kqueue
+    version: 1.2.1
+    sha: 8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea
+  - kind: registry
+    name: kqueue-sys
+    version: 1.1.2
+    sha: 07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087
+  - kind: registry
+    name: libc
+    version: 0.2.189
+    sha: 3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2
+  - kind: registry
+    name: libloading
+    version: 0.8.9
+    sha: d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55
+  - kind: registry
+    name: libm
+    version: 0.2.16
+    sha: b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981
+  - kind: registry
+    name: link-section
+    version: 0.19.3
+    sha: 39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9
+  - kind: registry
+    name: linktime-proc-macro
+    version: 0.2.3
+    sha: 7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616
+  - kind: registry
+    name: linux-raw-sys
+    version: 0.12.1
+    sha: 32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53
+  - kind: registry
+    name: litemap
+    version: 0.8.2
+    sha: 92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0
+  - kind: registry
+    name: litrs
+    version: 1.0.0
+    sha: 11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092
+  - kind: registry
+    name: lock_api
+    version: 0.4.14
+    sha: 224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965
+  - kind: registry
+    name: log
+    version: 0.4.33
+    sha: 0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad
+  - kind: registry
+    name: lru
+    version: 0.16.4
+    sha: 7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39
+  - kind: registry
+    name: lscolors
+    version: 0.21.0
+    sha: d60e266dfb1426eb2d24792602e041131fdc0236bb7007abc0e589acafd60929
+  - kind: registry
+    name: md-5
+    version: 0.11.0
+    sha: 69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98
+  - kind: registry
+    name: memchr
+    version: 2.8.3
+    sha: cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98
+  - kind: registry
+    name: memmap2
+    version: 0.9.11
+    sha: d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0
+  - kind: registry
+    name: memoffset
+    version: 0.9.1
+    sha: 488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a
+  - kind: registry
+    name: minimal-lexical
+    version: 0.2.1
+    sha: 68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a
+  - kind: registry
+    name: miniz_oxide
+    version: 0.8.9
+    sha: 1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316
+  - kind: registry
+    name: mio
+    version: 1.2.2
+    sha: 30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427
+  - kind: registry
+    name: nix
+    version: 0.31.3
+    sha: cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d
+  - kind: registry
+    name: nom
+    version: 7.1.3
+    sha: d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a
+  - kind: registry
+    name: nom
+    version: 8.0.0
+    sha: df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405
+  - kind: registry
+    name: notify
+    version: 8.2.0
+    sha: 4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3
+  - kind: registry
+    name: notify-types
+    version: 2.1.0
+    sha: 42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a
+  - kind: registry
+    name: nu-ansi-term
+    version: 0.50.3
+    sha: 7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5
+  - kind: registry
+    name: num-bigint
+    version: 0.4.8
+    sha: c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367
+  - kind: registry
+    name: num-conv
+    version: 0.2.2
+    sha: 521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441
+  - kind: registry
+    name: num-integer
+    version: 0.1.46
+    sha: 7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f
+  - kind: registry
+    name: num-modular
+    version: 0.6.1
+    sha: 17bb261bf36fa7d83f4c294f834e91256769097b3cb505d44831e0a179ac647f
+  - kind: registry
+    name: num-prime
+    version: 0.5.0
+    sha: b285c575532a33ef6fdd3a57640d0b1c70e6ca48644d6df7bbd4b7a0cfbbb12d
+  - kind: registry
+    name: num-traits
+    version: 0.2.19
+    sha: 071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841
+  - kind: registry
+    name: num_threads
+    version: 0.1.7
+    sha: 5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9
+  - kind: registry
+    name: objc2
+    version: 0.6.4
+    sha: 3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f
+  - kind: registry
+    name: objc2-encode
+    version: 4.1.0
+    sha: ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33
+  - kind: registry
+    name: once_cell
+    version: 1.21.4
+    sha: 9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50
+  - kind: registry
+    name: once_cell_polyfill
+    version: 1.70.2
+    sha: 384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe
+  - kind: registry
+    name: onig
+    version: 6.5.3
+    sha: 0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2
+  - kind: registry
+    name: onig_sys
+    version: 69.9.3
+    sha: 1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7
+  - kind: registry
+    name: openssl
+    version: 0.10.81
+    sha: 77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45
+  - kind: registry
+    name: openssl-macros
+    version: 0.1.1
+    sha: a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c
+  - kind: registry
+    name: openssl-src
+    version: 300.6.1+3.6.3
+    sha: 46eb8fb9fb3b61ce1c0f8a026c4c1a0714d3a9e138e7fbde78753ce2babc3846
+  - kind: registry
+    name: openssl-sys
+    version: 0.9.117
+    sha: b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695
+  - kind: registry
+    name: ordered-multimap
+    version: 0.7.3
+    sha: 49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79
+  - kind: registry
+    name: os_display
+    version: 0.1.4
+    sha: ad5fd71b79026fb918650dde6d125000a233764f1c2f1659a1c71118e33ea08f
+  - kind: registry
+    name: outref
+    version: 0.5.2
+    sha: 1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e
+  - kind: registry
+    name: parking_lot
+    version: 0.12.5
+    sha: 93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a
+  - kind: registry
+    name: parking_lot_core
+    version: 0.9.12
+    sha: 2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1
+  - kind: registry
+    name: parse_datetime
+    version: 0.16.0
+    sha: 503fd4c8b0685e5eb32a8276533611f63e3b44768e9e8724e73f6852c2542f82
+  - kind: registry
+    name: phf
+    version: 0.14.0
+    sha: 010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6
+  - kind: registry
+    name: phf_codegen
+    version: 0.14.0
+    sha: 41b585a510fb76fdebead6897982ef2a03a21d8e6cbcca904999742a4afc6ffe
+  - kind: registry
+    name: phf_generator
+    version: 0.14.0
+    sha: aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100
+  - kind: registry
+    name: phf_shared
+    version: 0.14.0
+    sha: c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89
+  - kind: registry
+    name: pin-project-lite
+    version: 0.2.17
+    sha: a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd
+  - kind: registry
+    name: pkg-config
+    version: 0.3.33
+    sha: 19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e
+  - kind: registry
+    name: platform-info
+    version: 2.1.0
+    sha: 9368d62437c8cbb7c31ee37fd8c08a7d390e09a3ff75698a674953f46705ffcb
+  - kind: registry
+    name: portable-atomic
+    version: 1.14.0
+    sha: 3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3
+  - kind: registry
+    name: portable-atomic-util
+    version: 0.2.7
+    sha: c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618
+  - kind: registry
+    name: potential_utf
+    version: 0.1.5
+    sha: 0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564
+  - kind: registry
+    name: powerfmt
+    version: 0.2.0
+    sha: 439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391
+  - kind: registry
+    name: ppv-lite86
+    version: 0.2.21
+    sha: 85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9
+  - kind: registry
+    name: pretty_assertions
+    version: 1.4.1
+    sha: 3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d
+  - kind: registry
+    name: prettyplease
+    version: 0.2.37
+    sha: 479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b
+  - kind: registry
+    name: proc-macro-crate
+    version: 3.5.0
+    sha: e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f
+  - kind: registry
+    name: proc-macro2
+    version: 1.0.107
+    sha: 985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9
+  - kind: registry
+    name: procfs
+    version: 0.18.0
+    sha: 25485360a54d6861439d60facef26de713b1e126bf015ec8f98239467a2b82f7
+  - kind: registry
+    name: procfs-core
+    version: 0.18.0
+    sha: e6401bf7b6af22f78b563665d15a22e9aef27775b79b149a66ca022468a4e405
+  - kind: registry
+    name: quote
+    version: 1.0.47
+    sha: 1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001
+  - kind: registry
+    name: r-efi
+    version: 6.0.0
+    sha: f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf
+  - kind: registry
+    name: radium
+    version: 0.7.0
+    sha: dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09
+  - kind: registry
+    name: rand
+    version: 0.10.2
+    sha: c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80
+  - kind: registry
+    name: rand
+    version: 0.8.7
+    sha: 22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a
+  - kind: registry
+    name: rand_chacha
+    version: 0.10.0
+    sha: 3e6af7f3e25ded52c41df4e0b1af2d047e45896c2f3281792ed68a1c243daedb
+  - kind: registry
+    name: rand_chacha
+    version: 0.3.1
+    sha: e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88
+  - kind: registry
+    name: rand_core
+    version: 0.10.1
+    sha: 63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69
+  - kind: registry
+    name: rand_core
+    version: 0.6.4
+    sha: ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c
+  - kind: registry
+    name: rayon
+    version: 1.12.0
+    sha: fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d
+  - kind: registry
+    name: rayon-core
+    version: 1.13.0
+    sha: 22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91
+  - kind: registry
+    name: redox_syscall
+    version: 0.5.18
+    sha: ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d
+  - kind: registry
+    name: regex
+    version: 1.13.1
+    sha: f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d
+  - kind: registry
+    name: regex-automata
+    version: 0.4.18
+    sha: ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2
+  - kind: registry
+    name: regex-lite
+    version: 0.1.9
+    sha: cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973
+  - kind: registry
+    name: regex-syntax
+    version: 0.8.11
+    sha: d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4
+  - kind: registry
+    name: relative-path
+    version: 1.9.3
+    sha: ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2
+  - kind: registry
+    name: rlimit
+    version: 0.11.0
+    sha: f35ee2729c56bb610f6dba436bf78135f728b7373bdffae2ec815b2d3eb98cc3
+  - kind: registry
+    name: roff
+    version: 1.1.1
+    sha: 323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189
+  - kind: registry
+    name: rstest
+    version: 0.26.1
+    sha: f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49
+  - kind: registry
+    name: rstest_macros
+    version: 0.26.1
+    sha: 9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0
+  - kind: registry
+    name: rstest_reuse
+    version: 0.7.0
+    sha: b3a8fb4672e840a587a66fc577a5491375df51ddb88f2a2c2a792598c326fe14
+  - kind: registry
+    name: rust-ini
+    version: 0.21.3
+    sha: 796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7
+  - kind: registry
+    name: rustc-hash
+    version: 2.1.3
+    sha: 6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d
+  - kind: registry
+    name: rustc_version
+    version: 0.4.1
+    sha: cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92
+  - kind: registry
+    name: rustix
+    version: 1.1.4
+    sha: b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190
+  - kind: registry
+    name: rustversion
+    version: 1.0.23
+    sha: cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f
+  - kind: registry
+    name: same-file
+    version: 1.0.6
+    sha: 93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502
+  - kind: registry
+    name: scopeguard
+    version: 1.2.0
+    sha: 94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49
+  - kind: registry
+    name: self_cell
+    version: 1.3.0
+    sha: 2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813
+  - kind: registry
+    name: selinux
+    version: 0.6.3
+    sha: 5e27b533f7b8e124356edfe653a21e5a5072585b4c0a67459519844c039bc4e1
+  - kind: registry
+    name: selinux-sys
+    version: 0.7.0
+    sha: acf9f7ddcfd31f0558b246d6ddc4a34fb4550668f364a09dd51f28409157e754
+  - kind: registry
+    name: semver
+    version: 1.0.28
+    sha: 8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd
+  - kind: registry
+    name: serde
+    version: 1.0.229
+    sha: 4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba
+  - kind: registry
+    name: serde_core
+    version: 1.0.229
+    sha: 67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48
+  - kind: registry
+    name: serde_derive
+    version: 1.0.229
+    sha: e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348
+  - kind: registry
+    name: serde_json
+    version: 1.0.151
+    sha: c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14
+  - kind: registry
+    name: sha1
+    version: 0.11.0
+    sha: aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214
+  - kind: registry
+    name: sha2
+    version: 0.11.0
+    sha: 446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4
+  - kind: registry
+    name: sha3
+    version: 0.12.0
+    sha: bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759
+  - kind: registry
+    name: shake
+    version: 0.1.0
+    sha: 09057cb2149ad4cbd2da1e26b351f9a4c354219421229c69c3063e6f61947c4a
+  - kind: registry
+    name: shlex
+    version: 1.3.0
+    sha: 0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64
+  - kind: registry
+    name: shlex
+    version: 2.0.1
+    sha: f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba
+  - kind: registry
+    name: signal-hook
+    version: 0.3.18
+    sha: d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2
+  - kind: registry
+    name: signal-hook-mio
+    version: 0.2.5
+    sha: b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc
+  - kind: registry
+    name: signal-hook-registry
+    version: 1.4.8
+    sha: c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b
+  - kind: registry
+    name: simd-adler32
+    version: 0.3.10
+    sha: 3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea
+  - kind: registry
+    name: siphasher
+    version: 1.0.3
+    sha: 8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649
+  - kind: registry
+    name: slab
+    version: 0.4.12
+    sha: 0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5
+  - kind: registry
+    name: sm3
+    version: 0.5.0
+    sha: da6a89ba31723d185fd7413b98c576a575f356d9b84729d8ecb6ead60000a5b6
+  - kind: registry
+    name: smallvec
+    version: 1.15.2
+    sha: 8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90
+  - kind: registry
+    name: smawk
+    version: 0.3.3
+    sha: e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100
+  - kind: registry
+    name: socket2
+    version: 0.6.5
+    sha: c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4
+  - kind: registry
+    name: spin
+    version: 0.10.1
+    sha: 023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3
+  - kind: registry
+    name: sponge-cursor
+    version: 0.1.0
+    sha: 3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620
+  - kind: registry
+    name: stable_deref_trait
+    version: 1.2.1
+    sha: 6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596
+  - kind: registry
+    name: statrs
+    version: 0.18.0
+    sha: 2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e
+  - kind: registry
+    name: string-interner
+    version: 0.20.0
+    sha: ad3df9b59e2eded8d825c7c4363ad339a20fb6bc0b9a4778560f518f59910b15
+  - kind: registry
+    name: strsim
+    version: 0.11.1
+    sha: 7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f
+  - kind: registry
+    name: syn
+    version: 2.0.119
+    sha: 872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297
+  - kind: registry
+    name: syn
+    version: 3.0.3
+    sha: 53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3
+  - kind: registry
+    name: synstructure
+    version: 0.13.2
+    sha: 728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2
+  - kind: registry
+    name: tap
+    version: 1.0.1
+    sha: 55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369
+  - kind: registry
+    name: tempfile
+    version: 3.27.0
+    sha: 32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd
+  - kind: registry
+    name: terminal_size
+    version: 0.4.4
+    sha: 230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874
+  - kind: registry
+    name: textwrap
+    version: 0.16.2
+    sha: c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057
+  - kind: registry
+    name: thiserror
+    version: 1.0.69
+    sha: b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52
+  - kind: registry
+    name: thiserror
+    version: 2.0.20
+    sha: ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f
+  - kind: registry
+    name: thiserror-impl
+    version: 1.0.69
+    sha: 4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1
+  - kind: registry
+    name: thiserror-impl
+    version: 2.0.20
+    sha: bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af
+  - kind: registry
+    name: time
+    version: 0.3.55
+    sha: cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134
+  - kind: registry
+    name: time-core
+    version: 0.1.9
+    sha: 9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109
+  - kind: registry
+    name: time-macros
+    version: 0.2.32
+    sha: 7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85
+  - kind: registry
+    name: tiny-keccak
+    version: 2.0.2
+    sha: 2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237
+  - kind: registry
+    name: tinystr
+    version: 0.8.4
+    sha: b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643
+  - kind: registry
+    name: toml_datetime
+    version: 1.1.1+spec-1.1.0
+    sha: 3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7
+  - kind: registry
+    name: toml_edit
+    version: 0.25.13+spec-1.1.0
+    sha: 6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b
+  - kind: registry
+    name: toml_parser
+    version: 1.1.3+spec-1.1.0
+    sha: 1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56
+  - kind: registry
+    name: type-map
+    version: 0.5.1
+    sha: cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90
+  - kind: registry
+    name: typed-path
+    version: 0.12.3
+    sha: 8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e
+  - kind: registry
+    name: typenum
+    version: 1.20.1
+    sha: b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20
+  - kind: registry
+    name: unic-langid
+    version: 0.9.6
+    sha: a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05
+  - kind: registry
+    name: unic-langid-impl
+    version: 0.9.6
+    sha: dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658
+  - kind: registry
+    name: unicode-ident
+    version: 1.0.24
+    sha: e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75
+  - kind: registry
+    name: unicode-linebreak
+    version: 0.1.5
+    sha: 3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f
+  - kind: registry
+    name: unicode-width
+    version: 0.1.14
+    sha: 7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af
+  - kind: registry
+    name: unicode-width
+    version: 0.2.2
+    sha: b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254
+  - kind: registry
+    name: unindent
+    version: 0.2.4
+    sha: 7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3
+  - kind: registry
+    name: unit-prefix
+    version: 0.5.2
+    sha: 81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3
+  - kind: registry
+    name: utf16_iter
+    version: 1.0.5
+    sha: c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246
+  - kind: registry
+    name: utf8_iter
+    version: 1.0.4
+    sha: b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be
+  - kind: registry
+    name: utf8parse
+    version: 0.2.2
+    sha: 06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821
+  - kind: registry
+    name: utmp-classic
+    version: 0.1.6
+    sha: e24c654e19afaa6b8f3877ece5d3bed849c2719c56f6752b18ca7da4fcc6e85a
+  - kind: registry
+    name: utmp-classic-raw
+    version: 0.1.3
+    sha: 22c226537a3d6e01c440c1926ca0256dbee2d19b2229ede6fc4863a6493dd831
+  - kind: registry
+    name: uutils_term_grid
+    version: 0.8.0
+    sha: 382d49b39de4a115f203305057741126b09a615892d773a2d419a2b816e30e39
+  - kind: registry
+    name: vcpkg
+    version: 0.2.15
+    sha: accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426
+  - kind: registry
+    name: version_check
+    version: 0.9.5
+    sha: 0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a
+  - kind: registry
+    name: vsimd
+    version: 0.8.0
+    sha: 5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64
+  - kind: registry
+    name: walkdir
+    version: 2.5.0
+    sha: 29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b
+  - kind: registry
+    name: wasi
+    version: 0.11.1+wasi-snapshot-preview1
+    sha: ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b
+  - kind: registry
+    name: wasm-bindgen
+    version: 0.2.126
+    sha: 4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4
+  - kind: registry
+    name: wasm-bindgen-macro
+    version: 0.2.126
+    sha: 167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1
+  - kind: registry
+    name: wasm-bindgen-macro-support
+    version: 0.2.126
+    sha: f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e
+  - kind: registry
+    name: wasm-bindgen-shared
+    version: 0.2.126
+    sha: dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24
+  - kind: registry
+    name: web-time
+    version: 1.1.0
+    sha: 5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb
+  - kind: registry
+    name: wild
+    version: 2.2.1
+    sha: a3131afc8c575281e1e80f36ed6a092aa502c08b18ed7524e86fbbb12bb410e1
+  - kind: registry
+    name: winapi
+    version: 0.3.9
+    sha: 5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419
+  - kind: registry
+    name: winapi-i686-pc-windows-gnu
+    version: 0.4.0
+    sha: ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6
+  - kind: registry
+    name: winapi-util
+    version: 0.1.11
+    sha: c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22
+  - kind: registry
+    name: winapi-x86_64-pc-windows-gnu
+    version: 0.4.0
+    sha: 712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f
+  - kind: registry
+    name: windows-core
+    version: 0.62.2
+    sha: b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb
+  - kind: registry
+    name: windows-implement
+    version: 0.60.2
+    sha: 053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf
+  - kind: registry
+    name: windows-interface
+    version: 0.59.3
+    sha: 3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358
+  - kind: registry
+    name: windows-link
+    version: 0.2.1
+    sha: f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5
+  - kind: registry
+    name: windows-result
+    version: 0.4.1
+    sha: 7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5
+  - kind: registry
+    name: windows-strings
+    version: 0.5.1
+    sha: 7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091
+  - kind: registry
+    name: windows-sys
+    version: 0.59.0
+    sha: 1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b
+  - kind: registry
+    name: windows-sys
+    version: 0.60.2
+    sha: f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb
+  - kind: registry
+    name: windows-sys
+    version: 0.61.2
+    sha: ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc
+  - kind: registry
+    name: windows-targets
+    version: 0.52.6
+    sha: 9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973
+  - kind: registry
+    name: windows-targets
+    version: 0.53.5
+    sha: 4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3
+  - kind: registry
+    name: windows_aarch64_gnullvm
+    version: 0.52.6
+    sha: 32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3
+  - kind: registry
+    name: windows_aarch64_gnullvm
+    version: 0.53.1
+    sha: a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53
+  - kind: registry
+    name: windows_aarch64_msvc
+    version: 0.52.6
+    sha: 09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469
+  - kind: registry
+    name: windows_aarch64_msvc
+    version: 0.53.1
+    sha: b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006
+  - kind: registry
+    name: windows_i686_gnu
+    version: 0.52.6
+    sha: 8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b
+  - kind: registry
+    name: windows_i686_gnu
+    version: 0.53.1
+    sha: 960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3
+  - kind: registry
+    name: windows_i686_gnullvm
+    version: 0.52.6
+    sha: 0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66
+  - kind: registry
+    name: windows_i686_gnullvm
+    version: 0.53.1
+    sha: fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c
+  - kind: registry
+    name: windows_i686_msvc
+    version: 0.52.6
+    sha: 240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66
+  - kind: registry
+    name: windows_i686_msvc
+    version: 0.53.1
+    sha: 1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2
+  - kind: registry
+    name: windows_x86_64_gnu
+    version: 0.52.6
+    sha: 147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78
+  - kind: registry
+    name: windows_x86_64_gnu
+    version: 0.53.1
+    sha: 9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499
+  - kind: registry
+    name: windows_x86_64_gnullvm
+    version: 0.52.6
+    sha: 24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d
+  - kind: registry
+    name: windows_x86_64_gnullvm
+    version: 0.53.1
+    sha: 0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1
+  - kind: registry
+    name: windows_x86_64_msvc
+    version: 0.52.6
+    sha: 589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec
+  - kind: registry
+    name: windows_x86_64_msvc
+    version: 0.53.1
+    sha: d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650
+  - kind: registry
+    name: winnow
+    version: 1.0.4
+    sha: 23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81
+  - kind: registry
+    name: write16
+    version: 1.0.0
+    sha: d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936
+  - kind: registry
+    name: writeable
+    version: 0.6.4
+    sha: 3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc
+  - kind: registry
+    name: wyz
+    version: 0.5.1
+    sha: 05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed
+  - kind: registry
+    name: xattr
+    version: 1.6.1
+    sha: 32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156
+  - kind: registry
+    name: yansi
+    version: 1.0.1
+    sha: cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049
+  - kind: registry
+    name: yoke
+    version: 0.8.3
+    sha: 709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5
+  - kind: registry
+    name: yoke-derive
+    version: 0.8.2
+    sha: de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e
+  - kind: registry
+    name: z85
+    version: 3.0.7
+    sha: c6e61e59a957b7ccee15d2049f86e8bfd6f66968fcd88f018950662d9b86e675
+  - kind: registry
+    name: zerocopy
+    version: 0.7.35
+    sha: 1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0
+  - kind: registry
+    name: zerocopy
+    version: 0.8.56
+    sha: 556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb
+  - kind: registry
+    name: zerocopy-derive
+    version: 0.7.35
+    sha: fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e
+  - kind: registry
+    name: zerocopy-derive
+    version: 0.8.56
+    sha: f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1
+  - kind: registry
+    name: zerofrom
+    version: 0.1.8
+    sha: 0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272
+  - kind: registry
+    name: zerofrom-derive
+    version: 0.1.7
+    sha: 11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1
+  - kind: registry
+    name: zerotrie
+    version: 0.2.5
+    sha: 4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f
+  - kind: registry
+    name: zerovec
+    version: 0.11.8
+    sha: bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8
+  - kind: registry
+    name: zerovec-derive
+    version: 0.11.6
+    sha: 34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da
+  - kind: registry
+    name: zip
+    version: 8.6.0
+    sha: 2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b
+  - kind: registry
+    name: zlib-rs
+    version: 0.6.7
+    sha: 34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12
+  - kind: registry
+    name: zmij
+    version: 1.0.23
+    sha: 29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b
+  - kind: registry
+    name: zopfli
+    version: 0.8.3
+    sha: f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249

--- a/include/aliases.yml
+++ b/include/aliases.yml
@@ -5,3 +5,4 @@ aliases:
   github: https://github.com/
   gitlab: https://gitlab.com/
   gnome: https://gitlab.gnome.org/GNOME/
+  crates: https://static.crates.io/

--- a/project.conf
+++ b/project.conf
@@ -63,6 +63,7 @@ plugins:
     sources:
       - git_repo
       - patch_queue
+      - cargo2
   - origin: junction
     junction: gnome-build-meta.bst
     elements:

--- a/tests/unit/test_build_depends.py
+++ b/tests/unit/test_build_depends.py
@@ -45,3 +45,45 @@ def test_manual_and_script_elements_depend_on_base_stack():
                 f"{bst_path.relative_to(REPO_ROOT)} is kind: {kind} but does not include "
                 f"base/base-stack.bst in build-depends"
             )
+
+
+def test_compose_elements_set_integrate_false():
+    """Ensure compose elements set integrate: False to avoid invoking nonexistent /bin/sh.
+
+    In FSDK 26.08, shell-less or minimal target images fail if BuildStream attempts
+    to execute integration scripts in the composed sandbox.
+    """
+    for bst_path in ELEMENTS_DIR.rglob("*.bst"):
+        if bst_path.name in ("freedesktop-sdk.bst", "gnome-build-meta.bst"):
+            continue
+
+        content = bst_path.read_text(encoding="utf-8")
+        if "kind: compose" not in content:
+            continue
+
+        data = yaml.safe_load(content)
+        if not isinstance(data, dict) or data.get("kind") != "compose":
+            continue
+
+        config = data.get("config", {})
+        assert config.get("integrate") is False, (
+            f"{bst_path.relative_to(REPO_ROOT)} is kind: compose but does not set "
+            f"'integrate: False' in config"
+        )
+
+
+def test_os_stack_uses_uutils_not_gnu():
+    """Bluefin Server OS must use uutils-coreutils, not GNU userspace."""
+    os_stack = ELEMENTS_DIR / "bluefin-server" / "os-stack.bst"
+    data = yaml.safe_load(os_stack.read_text(encoding="utf-8"))
+    depends = data.get("depends", [])
+
+    assert "bluefin-server/uutils-coreutils.bst" in depends, (
+        "os-stack.bst must include bluefin-server/uutils-coreutils.bst"
+    )
+    assert "freedesktop-sdk.bst:public-stacks/runtime-gnu.bst" not in depends, (
+        "os-stack.bst must NOT depend on GNU userspace (runtime-gnu.bst)"
+    )
+
+
+

--- a/tests/unit/test_sysupdate_transfers.py
+++ b/tests/unit/test_sysupdate_transfers.py
@@ -1,0 +1,229 @@
+"""Unit coverage for ``files/os/sysupdate.d/*.transfer``.
+
+``tests/unit/test_repart_layout.py`` already pins ``50-root.transfer`` against
+the installer repart config. The other two OTA transfer definitions —
+``60-uki.transfer`` (the boot UKI) and ``70-k0s.transfer`` (the k0s sysext) —
+have no coverage at all, and neither does the source-side artifact naming that
+systemd-sysupdate matches against.
+
+These tests assert the drift-prone contracts:
+
+* every transfer parses and carries ``[Transfer]``/``[Source]``/``[Target]``
+* every source pulls from this repo's own release feed over https
+* every source ``MatchPattern`` corresponds to an artifact name that some
+  element under ``elements/`` actually emits (``bluefin-server-ddi-<v>.raw.zst``,
+  ``bluefin-server-<v>.efi``, ``k0s-<v>.raw.zst``)
+* the k0s sysext transfer lands in ``/var/lib/extensions`` under a name that
+  ``files/k0s/sysext/extension-release.k0s`` (``NAME=k0s``) can merge
+"""
+
+import configparser
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SYSUPDATE_DIR = REPO_ROOT / "files" / "os" / "sysupdate.d"
+ELEMENTS_DIR = REPO_ROOT / "elements"
+EXTENSION_RELEASE = REPO_ROOT / "files" / "k0s" / "sysext" / "extension-release.k0s"
+
+RELEASE_FEED = "https://github.com/projectbluefin/server/releases/latest/download/"
+
+
+def transfer_paths() -> list[Path]:
+    return sorted(SYSUPDATE_DIR.glob("*.transfer"))
+
+
+def load_transfer(path: Path) -> configparser.ConfigParser:
+    parser = configparser.ConfigParser(strict=False)
+    # systemd keys are case sensitive; configparser lowercases them by default.
+    parser.optionxform = str
+    parser.read_string(path.read_text())
+    return parser
+
+
+def element_texts() -> str:
+    """Every element definition concatenated, for artifact-name lookups."""
+    return "\n".join(
+        p.read_text() for p in sorted(ELEMENTS_DIR.rglob("*.bst"))
+    )
+
+
+def split_match_pattern(pattern: str) -> tuple[str, str]:
+    """Return the literal ``(prefix, suffix)`` around sysupdate's ``@v`` token."""
+    assert "@v" in pattern, f"MatchPattern {pattern!r} carries no @v version token"
+    prefix, _, suffix = pattern.partition("@v")
+    return prefix, suffix
+
+
+def test_sysupdate_directory_is_populated():
+    paths = transfer_paths()
+    assert paths, f"no .transfer files found under {SYSUPDATE_DIR}"
+    names = {p.name for p in paths}
+    assert names == {
+        "50-root.transfer",
+        "60-uki.transfer",
+        "70-k0s.transfer",
+    }, f"unexpected transfer set {sorted(names)}; update this test with the contract"
+
+
+@pytest.mark.parametrize("path", transfer_paths(), ids=lambda p: p.name)
+def test_transfer_has_the_three_required_sections(path: Path):
+    parser = load_transfer(path)
+    for section in ("Transfer", "Source", "Target"):
+        assert parser.has_section(section), f"{path.name} is missing [{section}]"
+
+
+@pytest.mark.parametrize("path", transfer_paths(), ids=lambda p: p.name)
+def test_transfer_filename_is_ordered_and_lowercase(path: Path):
+    assert re.fullmatch(
+        r"[0-9]{2}-[a-z0-9-]+\.transfer", path.name
+    ), f"{path.name} must be NN-lowercase-name.transfer so ordering is explicit"
+
+
+def test_transfer_ordering_prefixes_are_unique():
+    prefixes = [p.name.split("-", 1)[0] for p in transfer_paths()]
+    assert len(prefixes) == len(set(prefixes)), (
+        f"duplicate sysupdate ordering prefixes {prefixes}; systemd-sysupdate "
+        "applies transfers in filename order and ties are undefined"
+    )
+
+
+@pytest.mark.parametrize("path", transfer_paths(), ids=lambda p: p.name)
+def test_source_pulls_from_this_repo_release_feed_over_https(path: Path):
+    source = load_transfer(path)["Source"]
+    assert source.get("Type") == "url-file", (
+        f"{path.name} [Source] Type is {source.get('Type')!r}; OTA payloads are "
+        "fetched as release files"
+    )
+    assert source.get("Path") == RELEASE_FEED, (
+        f"{path.name} [Source] Path is {source.get('Path')!r}, not {RELEASE_FEED!r}; "
+        "updates would be fetched from an unintended origin"
+    )
+
+
+@pytest.mark.parametrize("path", transfer_paths(), ids=lambda p: p.name)
+def test_source_match_pattern_is_versioned(path: Path):
+    pattern = load_transfer(path)["Source"].get("MatchPattern", "")
+    assert pattern, f"{path.name} [Source] has no MatchPattern"
+    prefix, suffix = split_match_pattern(pattern)
+    assert prefix and suffix, (
+        f"{path.name} MatchPattern {pattern!r} must have literal text on both "
+        "sides of @v or it will match unrelated release assets"
+    )
+
+
+@pytest.mark.parametrize("path", transfer_paths(), ids=lambda p: p.name)
+def test_every_source_artifact_is_produced_by_an_element(path: Path):
+    """The release asset a transfer downloads must be one the build emits.
+
+    Renaming an artifact in ``elements/oci/*.bst`` without updating the matching
+    transfer silently breaks OTA: sysupdate finds no candidate and reports the
+    system as up to date forever.
+    """
+    prefix, suffix = split_match_pattern(
+        load_transfer(path)["Source"]["MatchPattern"]
+    )
+    # Elements name artifacts with a BuildStream variable in the version slot,
+    # e.g. FNAME="k0s-%{k0s-version}.raw" plus a .zst compression step.
+    produced = re.compile(
+        re.escape(prefix) + r"%\{[a-z0-9-]+\}" + re.escape(suffix.removesuffix(".zst"))
+    )
+    assert produced.search(element_texts()), (
+        f"{path.name} expects release asset {prefix}<version>{suffix}, but no "
+        f"element under {ELEMENTS_DIR} emits a file named that way"
+    )
+
+
+def test_uki_transfer_installs_into_the_esp_boot_directory():
+    target = load_transfer(SYSUPDATE_DIR / "60-uki.transfer")["Target"]
+    assert target.get("Type") == "file", (
+        "the UKI is a plain file drop-in, not a partition or directory"
+    )
+    assert target.get("Path") == "/efi/EFI/Linux", (
+        f"UKI target path is {target.get('Path')!r}; systemd-boot only discovers "
+        "unified kernels under the ESP's EFI/Linux directory"
+    )
+    assert target.get("MatchPattern", "").endswith(".efi"), (
+        "the installed UKI must keep its .efi extension to be bootable"
+    )
+
+
+def test_uki_source_and_target_names_agree():
+    parser = load_transfer(SYSUPDATE_DIR / "60-uki.transfer")
+    assert parser["Source"]["MatchPattern"] == parser["Target"]["MatchPattern"], (
+        "the UKI is copied verbatim; a source/target name mismatch would leave "
+        "sysupdate unable to correlate installed and available versions"
+    )
+
+
+def test_k0s_sysext_transfer_lands_in_the_system_extension_directory():
+    target = load_transfer(SYSUPDATE_DIR / "70-k0s.transfer")["Target"]
+    assert target.get("Type") == "regular-file", (
+        "the k0s sysext is delivered as a decompressed regular file"
+    )
+    assert target.get("Path") == "/var/lib/extensions", (
+        f"k0s sysext target path is {target.get('Path')!r}; systemd-sysext only "
+        "merges images from /var/lib/extensions on a mutable-var system"
+    )
+    assert target.get("Mode") == "0644", (
+        f"k0s sysext mode is {target.get('Mode')!r}; the image must be readable "
+        "by systemd-sysext at merge time"
+    )
+
+
+def test_k0s_sysext_transfer_maintains_a_stable_current_symlink():
+    target = load_transfer(SYSUPDATE_DIR / "70-k0s.transfer")["Target"]
+    symlink = target.get("CurrentSymlink")
+    assert symlink == "k0s.raw", (
+        f"CurrentSymlink is {symlink!r}; systemd-sysext loads a fixed filename, "
+        "so without a stable symlink a version bump silently stops merging k0s"
+    )
+    prefix, suffix = split_match_pattern(target["MatchPattern"])
+    assert symlink == f"{prefix.rstrip('-')}{suffix}", (
+        f"CurrentSymlink {symlink!r} does not follow the versioned target name "
+        f"{target['MatchPattern']!r}"
+    )
+
+
+def test_k0s_sysext_transfer_decompresses_the_release_asset():
+    parser = load_transfer(SYSUPDATE_DIR / "70-k0s.transfer")
+    source = parser["Source"]["MatchPattern"]
+    target = parser["Target"]["MatchPattern"]
+    assert source.endswith(".raw.zst"), f"k0s release asset {source!r} is not zstd"
+    assert target == source.removesuffix(".zst"), (
+        f"k0s sysext installs as {target!r} but downloads {source!r}; a still "
+        "compressed image cannot be mounted by systemd-sysext"
+    )
+
+
+def test_k0s_sysext_image_name_matches_its_extension_release_name():
+    """systemd-sysext requires ``extension-release.<image-name>`` to agree.
+
+    The image installed by ``70-k0s.transfer`` is merged through the stable
+    ``k0s.raw`` symlink, so ``NAME=`` in ``files/k0s/sysext/extension-release.k0s``
+    must be ``k0s`` or the merge is rejected at boot.
+    """
+    assert EXTENSION_RELEASE.is_file(), f"{EXTENSION_RELEASE} missing"
+    fields = dict(
+        line.split("=", 1)
+        for line in EXTENSION_RELEASE.read_text().splitlines()
+        if "=" in line and not line.startswith("#")
+    )
+    symlink = load_transfer(SYSUPDATE_DIR / "70-k0s.transfer")["Target"][
+        "CurrentSymlink"
+    ]
+    image_name = symlink.removesuffix(".raw")
+    assert EXTENSION_RELEASE.name == f"extension-release.{image_name}", (
+        f"{EXTENSION_RELEASE.name} does not match the installed image name "
+        f"{image_name!r}"
+    )
+    assert fields.get("NAME") == image_name, (
+        f"extension-release NAME={fields.get('NAME')!r} but the sysext is merged "
+        f"as {image_name!r}; systemd-sysext refuses the mismatch"
+    )
+    assert fields.get("ID") == "_any", (
+        "ID must be _any: the sysext ships independently of the host os-release "
+        "version and would otherwise be rejected after an OS update"
+    )


### PR DESCRIPTION
## Summary

Prepares the repository for alpha release validation:
- Fix `elements/bluefin-server/uutils-coreutils.bst`: use `kind: manual` and add `base/base-stack.bst` build-dependency to satisfy element graph invariants.
- Add `crates: https://static.crates.io/` source alias to `include/aliases.yml` for cargo2 crate resolution.
- Clean up legacy k3s sysext symlink in `Justfile`.
- Adopt sysupdate transfer test coverage from PR #52 (`tests/unit/test_sysupdate_transfers.py`).
- Add `CONTEXT.md` domain glossary.

## Verification
- `just validate` passes cleanly.
- `just test-unit` (pytest + bats) passes (102 passed, 1 expected xfail, 41 bats ok).
