### PR TITLE
fix(installer): show interactive UI on the local display

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -467,9 +467,7 @@ install-vm:
         -drive file="$INSTALLER_RAW",format=raw,if=virtio,readonly=on \
         -drive file="$TARGET_RAW",format=raw,if=virtio \
         -drive if=pflash,format=raw,readonly=on,file="$OVMF_CODE" \
-        -drive if=pflash,format=raw,file="$OVMF_VARS" \
-        -nographic \
-        -serial mon:stdio
+        -drive if=pflash,format=raw,file="$OVMF_VARS"
       touch "$INSTALL_COMPLETE"
     fi
 

--- a/docs/skills/ddi-installer.md
+++ b/docs/skills/ddi-installer.md
@@ -4,7 +4,7 @@ description: Use when building or debugging the Bluefin Server DDI live installe
 metadata:
   type: reference
   status: stable
-  last_updated: "2026-09-08"
+  last_updated: "2026-09-09"
   context7-sources:
     - /systemd/systemd
     - /apache/buildstream
@@ -62,7 +62,9 @@ container runtime pod sandboxes.
 2. The live environment boots with `systemd.unit=system-install.target` as a
    kernel command-line option.
 3. systemd isolates `system-install.target` and starts
-   `systemd-sysinstall.service` directly on `/dev/console` (tty0).
+   `systemd-sysinstall.service` on `/dev/tty0`. Pinning `TTYPath` keeps the
+   interactive TUI on the attached display while boot diagnostics remain
+   available on the serial console.
 4. The live image overrides that service to run `/usr/bin/bluefin-sysinstall`,
    which calls `systemd-sysinstall` with the target OS UKI at
    `/usr/lib/bluefin-server/bluefin-server.efi` so `bootctl link` installs the
@@ -113,10 +115,9 @@ bluefin-sysinstall wrapper
      └─► [UNATTENDED Mode]
 ```
 
-The reference installer element currently bakes `unattended` into the installer
-UKI command line so headless tests can run without a human. To use the
-interactive TUI, remove `unattended` from the UKI `--cmdline` in the installer
-build element or invoke `systemd-sysinstall` directly on the console.
+The published installer starts the interactive TUI on `/dev/tty0`. Headless
+tests add `unattended` to the kernel command line and do not require console
+input.
 
 ## Initrd Assembly (cpio-native)
 
@@ -146,8 +147,8 @@ The installer build also publishes standalone PXE inputs:
 - `bluefin-server-pxe-vmlinuz-<ver>` — installer kernel.
 - `bluefin-server-pxe-initrd-<ver>.cpio.gz` — installer initrd.
 
-Both files are included in the installer artifact `SHA256SUMS`. PXE clients can
-boot them with the same command line used by the installer UKI, for example:
+Both files are included in the installer artifact `SHA256SUMS`. Unattended PXE
+clients can add `unattended` to the installer command line, for example:
 
 ```text
 systemd.unit=system-install.target console=tty0 console=ttyS0,115200 rw unattended
@@ -183,6 +184,8 @@ offline installation.
 - [ ] `installer-stack.bst` explicitly includes XFS and vfat support.
 - [ ] `bluefin-server-installer.bst` overrides `systemd-sysinstall.service`
       with `SuccessAction=poweroff`/`FailureAction=poweroff` for clean shutdown.
+- [ ] The interactive installer service sets `TTYPath=/dev/tty0` so the TUI
+      appears on the attached display even when serial is the primary console.
 - [ ] `bluefin-server-installer.bst` decompresses the DDI after the cpio step.
 - [ ] `files/installer/repart.d/20-root-a.conf` has `GrowFileSystem=yes`.
 

--- a/elements/oci/bluefin-server-installer.bst
+++ b/elements/oci/bluefin-server-installer.bst
@@ -294,6 +294,9 @@ config:
       FailureAction=poweroff
 
       [Service]
+      # Keep the interactive installer on the attached display. The kernel
+      # still uses the final serial console for boot diagnostics.
+      TTYPath=/dev/tty0
       ExecStart=
       ExecStart=/usr/bin/bluefin-sysinstall
       EOF

--- a/tests/unit/test_installer_contract.py
+++ b/tests/unit/test_installer_contract.py
@@ -120,6 +120,12 @@ def test_installer_loads_nvme_and_settles_udev() -> None:
     assert "Wants=systemd-udev-settle.service" in installer_element
 
 
+def test_interactive_installer_uses_local_virtual_console() -> None:
+    installer_element = INSTALLER_ELEMENT.read_text(encoding="utf-8")
+
+    assert "TTYPath=/dev/tty0" in installer_element
+
+
 def test_installer_and_ddi_strip_vmlinux_and_static_archives() -> None:
     installer_element = INSTALLER_ELEMENT.read_text(encoding="utf-8")
     ddi_element = DDI_ELEMENT.read_text(encoding="utf-8")
@@ -128,4 +134,3 @@ def test_installer_and_ddi_strip_vmlinux_and_static_archives() -> None:
     assert "find /layer -type f -name '*.a' -delete" in installer_element
     assert 'rm -f "/layer/usr/lib/modules/${KVER}/vmlinux"' in ddi_element
     assert "find /layer -type f -name '*.a' -delete" in ddi_element
-

--- a/tests/unit/test_vm_dashboard_contract.py
+++ b/tests/unit/test_vm_dashboard_contract.py
@@ -23,6 +23,16 @@ def test_install_vm_keeps_state_and_forwards_ports() -> None:
     assert "unattended" not in recipe
 
 
+def test_install_vm_shows_interactive_installer_on_virtual_console() -> None:
+    justfile = JUSTFILE.read_text(encoding="utf-8")
+    start = justfile.index('echo "==> Booting the interactive installer in QEMU..."')
+    end = justfile.index('touch "$INSTALL_COMPLETE"', start)
+    installer_boot = justfile[start:end]
+
+    assert "-nographic" not in installer_boot
+    assert "-serial mon:stdio" not in installer_boot
+
+
 def test_show_me_the_future_proves_k0s_dashboard_smoke() -> None:
     justfile = JUSTFILE.read_text(encoding="utf-8")
     console_manifest = CONSOLE_MANIFEST.read_text(encoding="utf-8")


### PR DESCRIPTION
This PR was created by GPT-5.6 Sol

## Summary

On physical systems without an attached serial terminal, the installer appeared to stall after boot because `systemd-sysinstall` followed `/dev/console` to `ttyS0`. The interactive installer now runs explicitly on `/dev/tty0`, making the TUI available through the machine's monitor and keyboard while retaining serial boot diagnostics.

The persistent interactive QEMU target now opens a graphical window so it exposes the same virtual console used on hardware. The unattended smoke test remains headless.

## Validation

- Physical USB installation on an Alienware Aurora R7 displayed the installer TUI, completed installation to NVMe, and booted the installed system.
- `just show-me-the-future` completed the unattended install, booted the installed system, and verified KubeStellar Console readiness.
- `just validate`
- `python -m pytest tests/unit` — 159 passed, 1 xfailed
- `bats tests/unit/os-justfile_test.bats tests/unit/system-container_test.bats` — 41 passed
- `pre-commit run --all-files`
