### PR TITLE
fix(sec): pin argocd-server container image by digest

### DIFF
--- a/files/k0s/manifests/argocd/install.yaml
+++ b/files/k0s/manifests/argocd/install.yaml
@@ -41,7 +41,7 @@ spec:
       serviceAccountName: argocd-server
       containers:
       - name: argocd-server
-        image: quay.io/argoproj/argocd:v2.12.3
+        image: quay.io/argoproj/argocd:v2.12.3@sha256:68894064bc381c19ea951029510aa614bd26bf46c2ec65ea445c7d8d095a9417
         command: [argocd-server, --insecure, --staticassets, /shared/app]
         ports:
         - containerPort: 8080


### PR DESCRIPTION
## Security Hardening

Pin `quay.io/argoproj/argocd:v2.12.3` to digest `sha256:68894064bc381c19ea951029510aa614bd26bf46c2ec65ea445c7d8d095a9417` in `files/k0s/manifests/argocd/install.yaml` to prevent mutable tag drift and ensure supply-chain integrity for control-plane GitOps deployments.

This partially addresses #74 by digest-pinning the argocd-server image. #74 remains open for the Argo CD version upgrade, `argocd-server --insecure`, and the other mutable images called out there.

### Verification
- `pytest tests/unit` (Passed)
- `python3 .github/scripts/docs-checks.py` (Passed)
- `just validate` (Passed)