### PR TITLE
fix(ci): restore dropped k0s sysext copy into dist/release/

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,7 @@ jobs:
           cp dist/bluefin-server-installer-*.raw.zst dist/bluefin-server-*.efi dist/release/
           cp dist/bluefin-server-pxe-vmlinuz-* dist/bluefin-server-pxe-initrd-*.cpio.gz dist/release/
           cp dist/ddi/bluefin-server-ddi-*.raw.zst dist/release/
+          cp dist/sysext/k0s-*.raw.zst dist/release/
           if [ -d dist/kernel ]; then
             cp dist/kernel/usr/lib/sysexts/*.raw dist/release/ 2>/dev/null || true
           fi


### PR DESCRIPTION
Fixes a regression from #92: the PXE-asset staging edit accidentally dropped `cp dist/sysext/k0s-*.raw.zst dist/release/`, so the k0s sysext stopped refreshing in the published release. Caught by `tests/unit/test_sysupdate_transfers.py` on the post-merge main run (unit job failed).

Verification: `python3 -m pytest tests/unit -q` — 201 passed, 1 xfailed. `just validate` — graph resolves.