### PR TITLE
feat(countme): ship the shared bluefin-countme reporter

### DIFF
--- a/elements/bluefin-server/os-countme.bst
+++ b/elements/bluefin-server/os-countme.bst
@@ -1,0 +1,35 @@
+kind: manual
+description: |
+  Weekly first-party countme reporting.
+
+  The reporter is not defined here. It is taken from projectbluefin/common
+  system_files/shared, the same unit and helper every other image ships, so this
+  image counts through exactly the same bluefin-countme as the rest of the family.
+
+  The preset from common enables the timer; this image applies systemd presets,
+  so no enablement symlink is needed.
+
+sources:
+  - kind: git_repo
+    url: github:projectbluefin/common.git
+    track: main
+    ref: v2026.08-108-gd46c4df9f9988002120cff4a66df8b163070fe6d
+
+build-depends:
+  - base/base-stack.bst
+
+depends:
+  # The reporter reads image metadata with jq and sends the ping with curl.
+  - freedesktop-sdk.bst:components/curl.bst
+  - freedesktop-sdk.bst:components/jq.bst
+  - bluefin-server/os-image-info.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+    - install -Dm755 system_files/shared/usr/libexec/bluefin-countme "%{install-root}%{prefix}/libexec/bluefin-countme"
+    - install -Dm644 system_files/shared/usr/lib/systemd/system/bluefin-countme.service -t "%{install-root}%{prefix}/lib/systemd/system/"
+    - install -Dm644 system_files/shared/usr/lib/systemd/system/bluefin-countme.timer -t "%{install-root}%{prefix}/lib/systemd/system/"
+    - install -Dm644 system_files/shared/usr/lib/systemd/system-preset/03-bluefin-countme.preset -t "%{install-root}%{prefix}/lib/systemd/system-preset/"

--- a/elements/bluefin-server/os-image-info.bst
+++ b/elements/bluefin-server/os-image-info.bst
@@ -1,0 +1,28 @@
+kind: manual
+description: |
+  Declare this image's identity at /usr/share/ublue-os/image-info.json.
+
+  The shared countme reporter from projectbluefin/common reads this file to know
+  which image it is counting. Every other image in the family already writes one;
+  this image is a DDI rather than an OCI image, so it has no image-info.json of
+  its own and no bootc ref to fall back to.
+
+  Only image-name is declared. A DDI is delivered by systemd-sysupdate and has no
+  container tag or flavor, and the reporter omits fields it is not given rather
+  than sending a placeholder.
+
+build-depends:
+  - base/base-stack.bst
+
+variables:
+  strip-binaries: ""
+
+config:
+  install-commands:
+    - mkdir -p "%{install-root}%{datadir}/ublue-os"
+    - |
+      cat >"%{install-root}%{datadir}/ublue-os/image-info.json" <<'JSON'
+      {
+        "image-name": "server"
+      }
+      JSON

--- a/elements/bluefin-server/os-stack.bst
+++ b/elements/bluefin-server/os-stack.bst
@@ -25,6 +25,10 @@ depends:
   - bluefin-server/os-sshd-preset.bst
   - bluefin-server/os-sshd-config.bst
 
+  # Image identity and weekly first-party countme reporting
+  - bluefin-server/os-image-info.bst
+  - bluefin-server/os-countme.bst
+
   # Flatcar LTS Kernel & Matching ZFS
   - flatcar/flatcar-kernel.bst
   - flatcar/flatcar-zfs.bst


### PR DESCRIPTION
This image did not report to `countme.projectbluefin.io` and had no way to, so it counted as nothing.

## The reporter is not defined here

`os-countme.bst` sources it from projectbluefin/common `system_files/shared` — the same unit, timer and helper every other image ships. This image counts through exactly the same `bluefin-countme` as the rest of the family and carries no countme code of its own.

Unlike Bluefin, LTS and Dakota, this repo has no `common.bst`, so the files come from a `git_repo` source rather than an existing junction.

The preset from common enables the timer, which this image already honours via `kind: import` into `system-preset` — no enablement symlink needed, unlike Dakota.

## Why os-image-info.bst exists

The reporter reads `/usr/share/ublue-os/image-info.json` to know which image it is counting. Every other image writes one during its build:

- Bluefin / LTS — `build_scripts/90-image-info.sh`
- Dakota — `include/os-release.yml`

This image has neither that file nor a bootc ref to fall back to, because it is a DDI delivered by `systemd-sysupdate` rather than an OCI image. Without it the reporter exits without sending, which is the correct behaviour but leaves the image uncounted.

**Only `image-name` is declared.** A DDI has no container tag or flavor, and the reporter omits fields it is not given rather than sending a placeholder. `os-release` here is `NAME="Bluefin Server"` / `ID=flatcar`, neither of which is a usable repo id.

## Dependencies

`curl` and `jq` are added explicitly — this image is minimal and had neither, and the reporter needs both.

## Follow-ups (filed)

- #95 — re-track the common ref once projectbluefin/common#1112 merges. Blocking once that branch is deleted.
- #96 — confirm the `components/curl.bst` path in the freedesktop-sdk junction.
- #97 — decide whether this image has a stream identifier worth counting, or whether `tag=unknown` is permanent.

### Original note

The `git_repo` ref is pinned to `v2026.08-108-gd46c4df9f...`, the tip of the branch in projectbluefin/common#1112. It must be re-tracked to `main` once that PR merges. I cannot run `bst track` here to generate the replacement.

If CI reports the `curl` component path differently in this junction, that is the one line to correct.